### PR TITLE
fix: specify minimum graphql dependency version

### DIFF
--- a/apollo-federation.gemspec
+++ b/apollo-federation.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files bin lib *.md LICENSE`.split("\n")
 
-  spec.add_dependency 'graphql'
+  spec.add_dependency 'graphql', '>= 1.9.6'
 
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rack'


### PR DESCRIPTION
With graphql 1.9.3, following the installation directions led to an exception: 
```
undefined method `graphql_name' for ApolloFederation::ServiceField:Module
```

Upgrading to latest (1.9.6) resolved the issue.