### PR TITLE
Handle rails params in Any

### DIFF
--- a/lib/apollo-federation/any.rb
+++ b/lib/apollo-federation/any.rb
@@ -9,8 +9,8 @@ module ApolloFederation
     def self.coerce_input(value, _ctx)
       # TODO: Should we convert it to a Mash-like object?
       result = {}
-      value.each_key do |key|
-        result[key.to_sym] = value[key]
+      value.each_pair do |key, val|
+        result[key.to_sym] = val
       end
 
       result


### PR DESCRIPTION
Using with rails causes NoMethodError as the value is an instance of rails params and they don't implement each_key method (when using default scaffolded GraphQLController)