### PR TITLE
feat: Support Interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ class BaseObject < GraphQL::Schema::Object
 end
 ```
 
+Include the `ApolloFederation::Interface` module in your base interface module:
+
+```ruby
+include GraphQL::Schema::Interface
+  field_class BaseField
+
+  definition_methods do
+    include ApolloFederation::Interface
+  end
+end
+```
+
 Finally, include the `ApolloFederation::Schema` module in your schema:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -49,12 +49,9 @@ Include the `ApolloFederation::Interface` module in your base interface module:
 ```ruby
 module BaseInterface
   include GraphQL::Schema::Interface
+  include ApolloFederation::Interface
 
   field_class BaseField
-
-  definition_methods do
-    include ApolloFederation::Interface
-  end
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ end
 Include the `ApolloFederation::Interface` module in your base interface module:
 
 ```ruby
-include GraphQL::Schema::Interface
+module BaseInterface
+  include GraphQL::Schema::Interface
+
   field_class BaseField
 
   definition_methods do

--- a/lib/apollo-federation.rb
+++ b/lib/apollo-federation.rb
@@ -3,6 +3,7 @@
 require 'apollo-federation/version'
 require 'apollo-federation/schema'
 require 'apollo-federation/object'
+require 'apollo-federation/interface'
 require 'apollo-federation/field'
 require 'apollo-federation/tracing/proto'
 require 'apollo-federation/tracing/node_map'

--- a/lib/apollo-federation/federated_document_from_schema_definition.rb
+++ b/lib/apollo-federation/federated_document_from_schema_definition.rb
@@ -26,6 +26,11 @@ module ApolloFederation
       merge_directives(object_node, object_type.metadata[:federation_directives])
     end
 
+    def build_interface_type_node(interface_type)
+      field_node = super
+      merge_directives(field_node, interface_type.metadata[:federation_directives])
+    end
+
     def build_field_node(field_type)
       field_node = super
       merge_directives(field_node, field_type.metadata[:federation_directives])

--- a/lib/apollo-federation/interface.rb
+++ b/lib/apollo-federation/interface.rb
@@ -3,20 +3,28 @@ require 'apollo-federation/has_directives'
 
 module ApolloFederation
   module Interface
-    include HasDirectives
-
-    def extend_type
-      add_directive(name: 'extends')
+    def self.included(klass)
+      klass.definition_methods do
+        include DefinitionMethods
+      end
     end
 
-    def key(fields:)
-      add_directive(
-        name: 'key',
-        arguments: [
-          name: 'fields',
-          values: fields,
-        ],
-      )
+    module DefinitionMethods
+      include HasDirectives
+
+      def extend_type
+        add_directive(name: 'extends')
+      end
+
+      def key(fields:)
+        add_directive(
+          name: 'key',
+          arguments: [
+            name: 'fields',
+            values: fields,
+          ],
+        )
+      end
     end
   end
 end

--- a/lib/apollo-federation/interface.rb
+++ b/lib/apollo-federation/interface.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'apollo-federation/has_directives'
 
 module ApolloFederation

--- a/lib/apollo-federation/interface.rb
+++ b/lib/apollo-federation/interface.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require 'apollo-federation/has_directives'
 
 module ApolloFederation

--- a/lib/apollo-federation/interface.rb
+++ b/lib/apollo-federation/interface.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'apollo-federation/has_directives'
+
+module ApolloFederation
+  module Interface
+    include HasDirectives
+
+    def extend_type
+      add_directive(name: 'extends')
+    end
+
+    def key(fields:)
+      add_directive(
+        name: 'key',
+        arguments: [
+          name: 'fields',
+          values: fields,
+        ],
+      )
+    end
+  end
+end

--- a/lib/apollo-federation/object.rb
+++ b/lib/apollo-federation/object.rb
@@ -11,7 +11,6 @@ module ApolloFederation
     module ClassMethods
       include HasDirectives
 
-      # TODO: We should support extending interfaces at some point
       def extend_type
         add_directive(name: 'extends')
       end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -29,7 +29,7 @@ module ApolloFederation
         end
 
         possible_entities = orig_defn.types.values.select do |type|
-          !type.introspection? && !type.default_scalar? &&
+          !type.introspection? && !type.default_scalar? && type.is_a?(GraphQL::ObjectType) &&
             type.metadata[:federation_directives]&.any? { |directive| directive[:name] == 'key' }
         end
 

--- a/spec/apollo-federation/service_field_spec.rb
+++ b/spec/apollo-federation/service_field_spec.rb
@@ -148,12 +148,9 @@ RSpec.describe ApolloFederation::ServiceField do
   it 'returns valid SDL for interface types' do
     base_interface = Module.new do
       include GraphQL::Schema::Interface
+      include ApolloFederation::Interface
 
       graphql_name 'Interface'
-
-      definition_methods do
-        include ApolloFederation::Interface
-      end
     end
 
     product = Module.new do

--- a/spec/apollo-federation/service_field_spec.rb
+++ b/spec/apollo-federation/service_field_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe ApolloFederation::ServiceField do
     )
   end
 
-  it 'returns valid SDL for interface' do
+  it 'returns valid SDL for interface types' do
     base_interface = Module.new do
       include GraphQL::Schema::Interface
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'pry-byebug'
+# require 'pry-byebug'
 
 RSpec::Matchers.define :match_sdl do |expected|
   match do |actual|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# require 'pry-byebug'
+require 'pry-byebug'
 
 RSpec::Matchers.define :match_sdl do |expected|
   match do |actual|


### PR DESCRIPTION
Following the spec defined in: https://www.apollographql.com/docs/apollo-server/federation/federation-spec/

**Notes:**
`directive @extends on OBJECT | INTERFACE`
`directive @key(fields: _FieldSet!) on OBJECT | INTERFACE`

-> Introduce a new `ApolloFederation::Interface` module that can be included in base interface modules, using the API outlined in https://graphql-ruby.org/type_definitions/interfaces#definition-methods

`union _Entity`
Unions cannot reference interface types, so the resolver excludes non-object types to generate this field.