### PR TITLE
docs: Clarify intent not to support legacy define API

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ To support [federated tracing](https://www.apollographql.com/docs/apollo-server/
     ```
 
 ## Known Issues and Limitations
- - Currently only works with class-based schemas
+ - Only works with class-based schemas, the legacy `.define` API will not be supported
  - Does not add directives to the output of `Schema.to_definition`. Since `graphql-ruby` doesn't natively support schema directives, the directives will only be visible to the [Apollo Gateway](https://www.apollographql.com/docs/apollo-server/api/apollo-gateway/) through the `Query._service` field (see the [Apollo Federation specification](https://www.apollographql.com/docs/apollo-server/federation/federation-spec/))
 
 ## Maintainers


### PR DESCRIPTION
## What's up?

On the graphql-ruby [roadmap](https://graphql-ruby.org/schema/class_based_api.html#roadmap), the `.define` API is marked for removal at `2.0` and sunsetted at `1.10` (which is the upcoming release). 

Hence just a small README change to clarify that we won't do any work to support the legacy API.