### PR TITLE
fix: specify dependency versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     apollo-federation (0.5.1)
-      google-protobuf
-      graphql
+      google-protobuf (~> 3.7)
+      graphql (~> 1.9.8)
 
 GEM
   remote: https://rubygems.org/

--- a/apollo-federation.gemspec
+++ b/apollo-federation.gemspec
@@ -26,9 +26,9 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files bin lib *.md LICENSE`.split("\n")
 
-  spec.add_dependency 'graphql'
+  spec.add_dependency 'graphql', '~> 1.9.8'
 
-  spec.add_runtime_dependency 'google-protobuf'
+  spec.add_runtime_dependency 'google-protobuf', '~> 3.7'
 
   spec.add_development_dependency 'actionpack'
   spec.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
BREAKING CHANGE: Requires graphql ~> 1.9.8 and google-protobuf ~> 3.7

There is no version specified for the dependencies. This is unpleasant for those trying to integrate the gem with existing codebase. Even though the library is its early development stage it would be nice to at least specify requirements. Versions could be adjusted later on, but it's way easier to spot a problem that to see misleading `protobuf` errors.