### PR TITLE
fix: guard compatibility for GetServiceDefinition requests

### DIFF
--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -49,7 +49,14 @@ module ApolloFederation
 
       def federation_sdl
         @federation_sdl ||= begin
+          warden = GraphQL::Schema::Warden.new(
+            default_filter,
+            schema: self,
+            context: {},
+          )
+
           document_from_schema = FederatedDocumentFromSchemaDefinition.new(self)
+          document_from_schema.instance_variable_set(:@warden, warden)
           GraphQL::Language::Printer.new.print(document_from_schema.document)
         end
       end


### PR DESCRIPTION
Hey!

Thanks for your work around this library. We're researching GQL gateway solutions right now. And apollo gateway one of the possible solutions for us, that's why this library is really useful for us.

Before start using the gateway, we need to understand how to start using a gateway with our codebase and for this, we need to think about migration to a gateway.

For example, we have a legacy GQL endpoint with `User` type like this:

```ruby
# user service
# `http://user_service/graphql` endpoint
class User < BaseObject
  key fields: 'id'

  field :id, ID, null: false
  field :reviews, [Review], null: true

  def reviews
    # HTTP call to another service
  end
end
```

For start using a gateway, we want to check that everything is good and make this migration without zero downtime. For this we want to see something like this:

```ruby
# user service
# `http://user_service/graphql` endpoint
class User < BaseObject
  key fields: 'id'

  field :id, ID, null: false

  # if we call it from client we want to use this field
  # if we call it from gateway we don't want to use this field
  if request == CLIENT
    field :reviews, [Review], null: true
  elsif request == GATEWAY
    # nothing
  end

  def reviews
    # HTTP call to another service
  end
end

# review service
# `http://review_service/graphql` endpoint
class User < BaseObject
  key fields: 'id'
  extend_type

  field :id, ID, null: false, external: true
  field :reviews, [Review], null: true

  def reviews
    # DB call
  end
end
```

To make this happen I found that I can use https://github.com/exAspArk/graphql-guard/ library with [schema masking](https://github.com/exAspArk/graphql-guard#schema-masking).

```ruby
class User < BaseObject
  key fields: 'id'

  field :id, ID, null: false
  field :reviews, [Review], null: true do
    mask ->(ctx) { ctx[:request_type] == 'client' }
  end
end
```

I tried to use it with the current implementation of apollo gateway but found an issue around `GetServiceDefinition` call:

![Screenshot 2019-11-06 at 02 02 29](https://user-images.githubusercontent.com/1147484/68253765-d7b01b00-0039-11ea-9a11-fa6115f4e2fa.jpg)

I started searching where the problem and found that you change `FederatedDocumentFromSchemaDefinition` but use it with an empty `warden` object ([link to original code](https://github.com/rmosolgo/graphql-ruby/blob/35dc19b57329294baf20f93d8f1265c563d733d9/lib/graphql/language/document_from_schema_definition.rb#L26-L30)).

I added hack from this PR and after that, I got the right behavior:

![Screenshot 2019-11-06 at 02 07 54](https://user-images.githubusercontent.com/1147484/68253954-5907ad80-003a-11ea-8bf2-fea3452c897f.jpg)

I'm not sure that my fix is good from a code perspective, but I'll be happy to start using the apollo federation ASAP. That's why I have a question: can we merge it soon or how I can change the code?
