### PR TITLE
fix: Send context to SDL generation / don't cache

### DIFF
--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -47,7 +47,7 @@ module ApolloFederation
         super
       end
 
-      def federation_sdl(context)
+      def federation_sdl(context: nil)
         document_from_schema = FederatedDocumentFromSchemaDefinition.new(self, context: context)
         GraphQL::Language::Printer.new.print(document_from_schema.document)
       end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -47,11 +47,9 @@ module ApolloFederation
         super
       end
 
-      def federation_sdl
-        @federation_sdl ||= begin
-          document_from_schema = FederatedDocumentFromSchemaDefinition.new(self)
-          GraphQL::Language::Printer.new.print(document_from_schema.document)
-        end
+      def federation_sdl(context)
+        document_from_schema = FederatedDocumentFromSchemaDefinition.new(self, context: context)
+        GraphQL::Language::Printer.new.print(document_from_schema.document)
       end
     end
   end

--- a/lib/apollo-federation/service_field.rb
+++ b/lib/apollo-federation/service_field.rb
@@ -10,7 +10,7 @@ module ApolloFederation
     field(:_service, Service, null: false)
 
     def _service
-      { sdl: context.schema.class.federation_sdl }
+      { sdl: context.schema.class.federation_sdl(context) }
     end
   end
 end


### PR DESCRIPTION
Recently, `graphql-ruby` started supporting visibility rules during SDL generation (PR: https://github.com/rmosolgo/graphql-ruby/pull/2637).  In order to utilize dynamic values set in the query context, it needs to be forwarded to `FederatedDocumentFromSchemaDefinition`.  Additionally, the current caching mechanism poses a problem if you have several gateways/clients with different visibility rules, so it has been removed.