### PR TITLE
chore(deps): Allow for GraphQL dependencies >= 1.10.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     apollo-federation (1.0.0)
       google-protobuf (~> 3.7)
-      graphql (~> 1.9.8)
+      graphql (>= 1.9.8)
 
 GEM
   remote: https://rubygems.org/
@@ -34,8 +34,8 @@ GEM
     crass (1.0.5)
     diff-lcs (1.3)
     erubi (1.8.0)
-    google-protobuf (3.11.1)
-    graphql (1.9.16)
+    google-protobuf (3.11.2)
+    graphql (1.10.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)

--- a/apollo-federation.gemspec
+++ b/apollo-federation.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.files = `git ls-files bin lib *.md LICENSE`.split("\n")
 
-  spec.add_dependency 'graphql', '~> 1.9.8'
+  spec.add_dependency 'graphql', '>= 1.9.8'
 
   spec.add_runtime_dependency 'google-protobuf', '~> 3.7'
 

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -15,6 +15,26 @@ module ApolloFederation
       def to_graphql
         orig_defn = super
 
+        possible_entities = orig_defn.types.values.select do |type|
+          !type.introspection? && !type.default_scalar? && type.is_a?(GraphQL::ObjectType) &&
+            type.metadata[:federation_directives]&.any? { |directive| directive[:name] == 'key' }
+        end
+
+        @query_object = federation_query
+
+        if !possible_entities.empty?
+          entity_type = Class.new(Entity) do
+            possible_types(*possible_entities)
+          end
+          # TODO: Should/can we encapsulate all of this inside the module? What's the best/most Ruby
+          # way to split this out?
+          @query_object.define_entities_field(entity_type)
+        end
+
+        super
+      end
+
+      def federation_query
         if query.nil?
           base = GraphQL::Schema::Object
         elsif Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('1.10.0')
@@ -23,30 +43,12 @@ module ApolloFederation
           base = query.metadata[:type_class]
         end
 
-        federation_query = Class.new(base) do
+        Class.new(base) do
           graphql_name 'Query'
 
           include EntitiesField
           include ServiceField
         end
-
-        possible_entities = orig_defn.types.values.select do |type|
-          !type.introspection? && !type.default_scalar? && type.is_a?(GraphQL::ObjectType) &&
-            type.metadata[:federation_directives]&.any? { |directive| directive[:name] == 'key' }
-        end
-
-        if !possible_entities.empty?
-          entity_type = Class.new(Entity) do
-            possible_types(*possible_entities)
-          end
-          # TODO: Should/can we encapsulate all of this inside the module? What's the best/most Ruby
-          # way to split this out?
-          federation_query.define_entities_field(entity_type)
-        end
-
-        @query_object = federation_query
-
-        super
       end
 
       def federation_sdl(context: nil)

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -17,12 +17,10 @@ module ApolloFederation
 
         if query.nil?
           base = GraphQL::Schema::Object
+        elsif Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('1.10.0')
+          base = query
         else
-          if Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new("1.10.0")
-            base = query
-          else
-            base = query.metadata[:type_class]
-          end
+          base = query.metadata[:type_class]
         end
 
         federation_query = Class.new(base) do

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -18,7 +18,11 @@ module ApolloFederation
         if query.nil?
           base = GraphQL::Schema::Object
         else
-          base = query.metadata[:type_class]
+          if Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new("1.10.0")
+            base = query
+          else
+            base = query.metadata[:type_class]
+          end
         end
 
         federation_query = Class.new(base) do
@@ -42,7 +46,7 @@ module ApolloFederation
           federation_query.define_entities_field(entity_type)
         end
 
-        query(federation_query)
+        @query_object = federation_query
 
         super
       end


### PR DESCRIPTION
graphql-ruby 1.10.0 brought some breaking changes to its to_graphql method. See: https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md#1100-20-jan-2020