### PR TITLE
fix: service field context

### DIFF
--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -47,7 +47,7 @@ module ApolloFederation
         super
       end
 
-      def federation_sdl(context:)
+      def federation_sdl(context = nil)
         document_from_schema = FederatedDocumentFromSchemaDefinition.new(self, context: context)
         GraphQL::Language::Printer.new.print(document_from_schema.document)
       end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -47,7 +47,7 @@ module ApolloFederation
         super
       end
 
-      def federation_sdl(context = nil)
+      def federation_sdl(context: nil)
         document_from_schema = FederatedDocumentFromSchemaDefinition.new(self, context: context)
         GraphQL::Language::Printer.new.print(document_from_schema.document)
       end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -47,7 +47,7 @@ module ApolloFederation
         super
       end
 
-      def federation_sdl(context: nil)
+      def federation_sdl(context:)
         document_from_schema = FederatedDocumentFromSchemaDefinition.new(self, context: context)
         GraphQL::Language::Printer.new.print(document_from_schema.document)
       end

--- a/lib/apollo-federation/service_field.rb
+++ b/lib/apollo-federation/service_field.rb
@@ -10,7 +10,7 @@ module ApolloFederation
     field(:_service, Service, null: false)
 
     def _service
-      { sdl: context.schema.class.federation_sdl(context: context) }
+      { sdl: context.schema.class.federation_sdl(context) }
     end
   end
 end

--- a/lib/apollo-federation/service_field.rb
+++ b/lib/apollo-federation/service_field.rb
@@ -10,7 +10,7 @@ module ApolloFederation
     field(:_service, Service, null: false)
 
     def _service
-      { sdl: context.schema.class.federation_sdl(context) }
+      { sdl: context.schema.class.federation_sdl(context: context) }
     end
   end
 end


### PR DESCRIPTION
Methods definition here:
https://github.com/Gusto/apollo-federation-ruby/blob/master/lib/apollo-federation/schema.rb#L50

Currently we get an exception when running the service check command:
```
apollo schema:check --endpoint=http://localhost:3000/graphql ...
```
Results in:
```
unknown keyword: current_user
/Users/matt/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/apollo-federation-1.0.1/lib/apollo-federation/schema.rb:50:in `federation_sdl'
/Users/matt/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/apollo-federation-1.0.1/lib/apollo-federation/service_field.rb:13:in `_service'
/Users/matt/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/graphql-1.9.19/lib/graphql/schema/field.rb:652:in `public_send'
```

Our context
```
context = { current_user: current_user }
```

Changing this to a required keyword argument makes tests surface the bug. The code change fixes the tests.