### PR TITLE
fix(lazy resolve): Handle problem with sync resolve

### DIFF
--- a/lib/apollo-federation/entity_type_resolution_extension.rb
+++ b/lib/apollo-federation/entity_type_resolution_extension.rb
@@ -2,17 +2,15 @@
 
 class EntityTypeResolutionExtension < GraphQL::Schema::FieldExtension
   def after_resolve(value:, context:, **_rest)
-    synced_value =
-      value.map do |type, result|
-        [type, context.query.schema.sync_lazy(result)]
+    value.map do |type, result|
+      context.schema.after_lazy(result) do |resolved_value|
+        # TODO: This isn't 100% correct: if (for some reason) 2 different resolve_reference calls
+        # return the same object, it might not have the right type
+        # Right now, apollo-federation just adds a __typename property to the result,
+        # but I don't really like the idea of modifying the resolved object
+        context[resolved_value] = type
+        resolved_value
       end
-
-    # TODO: This isn't 100% correct: if (for some reason) 2 different resolve_reference calls
-    # return the same object, it might not have the right type
-    # Right now, apollo-federation just adds a __typename property to the result,
-    # but I don't really like the idea of modifying the resolved object
-    synced_value.each { |type, result| context[result] = type }
-
-    synced_value.map { |_, result| result }
+    end
   end
 end

--- a/spec/apollo-federation/entities_field_spec.rb
+++ b/spec/apollo-federation/entities_field_spec.rb
@@ -225,12 +225,12 @@ RSpec.describe ApolloFederation::EntitiesField do
               context 'when resolve_reference returns a lazy object' do
                 let(:lazy_entity) do
                   Class.new do
-                    def initialize(data)
-                      @data = data
+                    def initialize(callable)
+                      @callable = callable
                     end
 
                     def load_entity
-                      @data
+                      @callable.call
                     end
                   end
                 end
@@ -245,24 +245,78 @@ RSpec.describe ApolloFederation::EntitiesField do
                   end
                 end
 
-                let(:type_with_key) do
+                let(:resolve_method) do
                   lazy_entity_class = lazy_entity
+
+                  lambda do |reference, _context|
+                    if reference[:id] == 123
+                      lazy_entity_class.new(-> { { id: 123, other_field: 'more data' } })
+                    end
+                  end
+                end
+
+                let(:type_with_key) do
+                  resolve_method_pointer = resolve_method
                   Class.new(base_object) do
                     graphql_name 'TypeWithKey'
                     key fields: 'id'
                     field :id, 'ID', null: false
                     field :other_field, 'String', null: false
 
-                    define_singleton_method :resolve_reference do |reference, _context|
-                      if reference[:id] == 123
-                        lazy_entity_class.new(id: 123, other_field: 'more data')
-                      end
-                    end
+                    define_singleton_method :resolve_reference, &resolve_method_pointer
                   end
                 end
 
                 it { is_expected.to match_array [{ 'id' => id.to_s, 'otherField' => 'more data' }] }
                 it { expect(errors).to be_nil }
+
+                context 'when lazy object raises an error' do
+                  let(:base_schema) do
+                    Class.new(GraphQL::Schema) do
+                      include ApolloFederation::Schema
+                    end
+                  end
+
+                  let(:id1) { 123 }
+                  let(:id2) { 321 }
+                  let(:representations) do
+                    [
+                      { __typename: typename, id: id1 },
+                      { __typename: typename, id: id2 },
+                    ]
+                  end
+
+                  let(:resolve_method) do
+                    lazy_entity_class = lazy_entity
+
+                    lambda do |reference, _context|
+                      case reference[:id]
+                      when 123
+                        lazy_entity_class.new(-> { { id: 123, other_field: 'more data' } })
+                      when 321
+                        lazy_entity_class.new(-> { raise(GraphQL::ExecutionError, 'error') })
+                      end
+                    end
+                  end
+
+                  specify do
+                    expect(execute_query.to_h).to match(
+                      'data' => {
+                        '_entities' => [
+                          { 'id' => id.to_s, 'otherField' => 'more data' },
+                          nil,
+                        ],
+                      },
+                      'errors' => [
+                        {
+                          'locations' => [{ 'column' => 3, 'line' => 2 }],
+                          'message' => 'error',
+                          'path' => ['_entities', 1],
+                        },
+                      ],
+                    )
+                  end
+                end
               end
             end
           end


### PR DESCRIPTION
Hey!

Thanks for your work around this library.
When we are trying to implement authorization in our application we use exceptions and middleware, it works fine for everything except this gem, because the sync is being called [here](https://github.com/Gusto/apollo-federation-ruby/blob/master/lib/apollo-federation/entity_type_resolution_extension.rb#L7) which nullifies all data returned by `_entities` field even if the only one object is not authorized.

## Examples

What we get without this patch:
```
{
  "data": null,
  "errors": [
    {
      "message": "Not authorized (Talent)",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "_entities"
      ],
      "extensions": {
        "code": "UNAUTHORIZED"
      }
    }
  ]
}
```
what we want to get: 
```
{
  "data": {
    "_entities": [
      {
        "id": "VjEtVGFsZW50LTEwMDAwMA",
        "status": "active",
        "resumeUrl": "/ConstructionWorker/resume/talent-1"
      },
      null
    ]
  },
  "errors": [
    {
      "message": "Not authorized (Talent)",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "_entities",
        1
      ],
      "extensions": {
        "code": "UNAUTHORIZED"
      }
    }
  ]
}
```