### PR TITLE
fix(lazy resolve): Handle problem with sync resolve

### DIFF
--- a/lib/apollo-federation/entity_type_resolution_extension.rb
+++ b/lib/apollo-federation/entity_type_resolution_extension.rb
@@ -2,17 +2,15 @@
 
 class EntityTypeResolutionExtension < GraphQL::Schema::FieldExtension
   def after_resolve(value:, context:, **_rest)
-    synced_value =
-      value.map do |type, result|
-        [type, context.query.schema.sync_lazy(result)]
+    value.map do |type, result|
+      context.schema.after_lazy(result) do |resolved_value|
+        # TODO: This isn't 100% correct: if (for some reason) 2 different resolve_reference calls
+        # return the same object, it might not have the right type
+        # Right now, apollo-federation just adds a __typename property to the result,
+        # but I don't really like the idea of modifying the resolved object
+        context[resolved_value] = type
+        resolved_value
       end
-
-    # TODO: This isn't 100% correct: if (for some reason) 2 different resolve_reference calls
-    # return the same object, it might not have the right type
-    # Right now, apollo-federation just adds a __typename property to the result,
-    # but I don't really like the idea of modifying the resolved object
-    synced_value.each { |type, result| context[result] = type }
-
-    synced_value.map { |_, result| result }
+    end
   end
 end

--- a/spec/apollo-federation/entities_field_spec.rb
+++ b/spec/apollo-federation/entities_field_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe ApolloFederation::EntitiesField do
             type Query {
               _service: _Service!
             }
+
             """
             The sdl representing the federated service capabilities. Includes federation
             directives, removes federation types, and includes rest of full schema after
@@ -76,12 +77,16 @@ RSpec.describe ApolloFederation::EntitiesField do
                 _service: _Service!
                 typeWithKey: TypeWithKey
               }
+
               type TypeWithKey {
                 id: ID!
                 otherField: String
               }
+
               scalar _Any
+
               union _Entity = TypeWithKey
+
               """
               The sdl representing the federated service capabilities. Includes federation
               directives, removes federation types, and includes rest of full schema after
@@ -119,16 +124,21 @@ RSpec.describe ApolloFederation::EntitiesField do
               type Mutation {
                 typeWithKey: TypeWithKey
               }
+
               type Query {
                 _entities(representations: [_Any!]!): [_Entity]!
                 _service: _Service!
               }
+
               type TypeWithKey {
                 id: ID!
                 otherField: String
               }
+
               scalar _Any
+
               union _Entity = TypeWithKey
+
               """
               The sdl representing the federated service capabilities. Includes federation
               directives, removes federation types, and includes rest of full schema after


### PR DESCRIPTION
Hey!

Thanks for your work around this library.
When we are trying to implement authorization in our application we use exceptions and middleware, it works fine for everything except this gem, because the sync is being called [here](https://github.com/Gusto/apollo-federation-ruby/blob/master/lib/apollo-federation/entity_type_resolution_extension.rb#L7) which nullifies all data returned by `_entities` field even if the only one object is not authorized.

## Examples

What we get without this patch:
```
{
  "data": null,
  "errors": [
    {
      "message": "Not authorized (Talent)",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "_entities"
      ],
      "extensions": {
        "code": "UNAUTHORIZED"
      }
    }
  ]
}
```
what we want to get: 
```
{
  "data": {
    "_entities": [
      {
        "id": "VjEtVGFsZW50LTEwMDAwMA",
        "status": "active",
        "resumeUrl": "/ConstructionWorker/resume/talent-1"
      },
      null
    ]
  },
  "errors": [
    {
      "message": "Not authorized (Talent)",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "_entities",
        1
      ],
      "extensions": {
        "code": "UNAUTHORIZED"
      }
    }
  ]
}
```