### PR TITLE
fix: Fix spec to account for breaking change to graphql-ruby 1.10.0

### DIFF
--- a/spec/apollo-federation/tracing_spec.rb
+++ b/spec/apollo-federation/tracing_spec.rb
@@ -323,6 +323,7 @@ RSpec.describe ApolloFederation::Tracing do
       Class.new(GraphQL::Schema) do
         use ApolloFederation::Tracing
         use GraphQL::Execution::Interpreter
+        use GraphQL::Analysis::AST
       end
     end
 


### PR DESCRIPTION
Account for [breaking change](https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md#1100-20-jan-2020) to `graphql-ruby 1.10.0` in spec

> Class-based schemas using the interpreter must add use GraphQL::Analysis::AST to their schema (and update their custom analyzers, see https://graphql-ruby.org/queries/ast_analysis.html) #2363

