### PR TITLE
fix: Fix _service field type owner

### DIFF
--- a/graphql-1.9.gemfile.lock
+++ b/graphql-1.9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    apollo-federation (1.1.0)
+    apollo-federation (1.1.1)
       google-protobuf (~> 3.7)
       graphql (>= 1.9.8)
 

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -33,7 +33,7 @@ module ApolloFederation
           base = query_obj.metadata[:type_class]
         end
 
-        Class.new(base) do
+        klass = Class.new(base) do
           # TODO: Maybe the name should inherit from the original Query name
           # Or MAYBE we should just modify the original class?
           graphql_name 'Query'
@@ -41,6 +41,9 @@ module ApolloFederation
           include EntitiesField
           include ServiceField
         end
+
+        klass.define_service_field
+        klass
       end
     end
 

--- a/lib/apollo-federation/service_field.rb
+++ b/lib/apollo-federation/service_field.rb
@@ -5,9 +5,17 @@ require 'apollo-federation/service'
 
 module ApolloFederation
   module ServiceField
-    extend GraphQL::Schema::Member::HasFields
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
 
-    field(:_service, Service, null: false)
+    module ClassMethods
+      extend GraphQL::Schema::Member::HasFields
+
+      def define_service_field
+        field(:_service, Service, null: false)
+      end
+    end
 
     def _service
       schema_class = context.schema.is_a?(GraphQL::Schema) ? context.schema.class : context.schema

--- a/spec/apollo-federation/entities_field_spec.rb
+++ b/spec/apollo-federation/entities_field_spec.rb
@@ -69,6 +69,16 @@ RSpec.describe ApolloFederation::EntitiesField do
           end
         end
 
+        it 'sets the Query as the owner to the _entities field' do
+          expect(
+            schema.graphql_definition
+              .types['Query']
+              .fields['_entities']
+              .metadata[:type_class]
+              .owner.graphql_name,
+          ).to eq('Query')
+        end
+
         it 'adds an _entities field to the Query object' do
           expect(schema.to_definition).to match_sdl(
             <<~GRAPHQL,

--- a/spec/apollo-federation/service_field_spec.rb
+++ b/spec/apollo-federation/service_field_spec.rb
@@ -79,6 +79,16 @@ RSpec.describe ApolloFederation::ServiceField do
       end
     end
 
+    it 'sets the Query as the owner to the _service field' do
+      expect(
+        base_schema.graphql_definition
+              .types['Query']
+              .fields['_service']
+              .metadata[:type_class]
+              .owner.graphql_name,
+      ).to eq('Query')
+    end
+
     it 'returns the federation SDL for the schema' do
       product = Class.new(base_object) do
         graphql_name 'Product'


### PR DESCRIPTION
The field was previously defined in the module making the
ApolloFederation::ServiceField the owner of the type instead of the
root Query.