### PR TITLE
fix: Add types with fields that @requires to _Entity union

### DIFF
--- a/spec/apollo-federation/entities_field_spec.rb
+++ b/spec/apollo-federation/entities_field_spec.rb
@@ -53,12 +53,23 @@ RSpec.describe ApolloFederation::EntitiesField do
         end
       end
 
+      let(:type_with_requires) do
+        Class.new(base_object) do
+          graphql_name 'TypeWithRequires'
+          extend_type
+          field :value, 'String', null: false, external: true
+          field :additional_field, 'String', null: true, requires: { fields: 'value' }
+        end
+      end
+
       context 'when a Query object is provided' do
         let(:query) do
           type_with_key_class = type_with_key
+          type_with_requires_class = type_with_requires
           Class.new(base_object) do
             graphql_name 'Query'
             field :type_with_key, type_with_key_class, null: true
+            field :type_with_requires, type_with_requires_class, null: true
           end
         end
 
@@ -86,6 +97,7 @@ RSpec.describe ApolloFederation::EntitiesField do
                 _entities(representations: [_Any!]!): [_Entity]!
                 _service: _Service!
                 typeWithKey: TypeWithKey
+                typeWithRequires: TypeWithRequires
               }
 
               type TypeWithKey {
@@ -93,9 +105,14 @@ RSpec.describe ApolloFederation::EntitiesField do
                 otherField: String
               }
 
+              type TypeWithRequires {
+                additionalField: String
+                value: String!
+              }
+
               scalar _Any
 
-              union _Entity = TypeWithKey
+              union _Entity = TypeWithKey | TypeWithRequires
 
               """
               The sdl representing the federated service capabilities. Includes federation


### PR DESCRIPTION
Types that have fields that uses `@requires` directive needs to be part of `_Entity` union and be resolvable by `_entities` query field.

It is useful when one schema is extending types that are kinda of "singletons" like `viewer`, eg:
```
# Accounts service
type Query {
  viewer: Viewer!
}

type Viewer {
  my_products: [Product!]!
}

# Reviews service
type Viewer @extend {
  my_products: [Product!]! @external
  my_product_reviews: [Review!]! @requires fields: 'my_products { id }'
}
```
The query to gateway:
```
query {
  viewer {
     my_product_reviews {
       body
     }
  }
}
```
would get Viewer form accounts service and try to resolve `my_product_reviews` from reviews service using _entities query. Because there is no `@key` directive on viewer it is not part of `_Entity` union and `_entities` query would fail. 

The change makes the gem to add types with fields with `@requires` directive to be part of `_Entities` union.

