### PR TITLE
ci: Fix graphql-1.9.gemfile.lock

### DIFF
--- a/graphql-1.9.gemfile.lock
+++ b/graphql-1.9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    apollo-federation (1.1.0)
+    apollo-federation (1.1.1)
       google-protobuf (~> 3.7)
       graphql (>= 1.9.8)
 


### PR DESCRIPTION
Semantic release bot does not update the `graphql-1.9.gemfile.lock` file. 

https://github.com/Gusto/apollo-federation-ruby/commit/97cc246ed9b34a43aac94dd8bdf33dab5e8338c4#diff-e79a60dc6b85309ae70a6ea8261eaf95