### PR TITLE
fix: Inherit federation directives

### DIFF
--- a/lib/apollo-federation/has_directives.rb
+++ b/lib/apollo-federation/has_directives.rb
@@ -7,8 +7,8 @@ module ApolloFederation
     end
 
     def federation_directives
-      if is_a?(Class) && superclass.respond_to?(:federation_directives)
-        own_federation_directives + superclass.federation_directives
+      if is_a?(Class)
+        own_federation_directives + find_inherited_value(:federation_directives, [])
       else
         own_federation_directives
       end

--- a/lib/apollo-federation/has_directives.rb
+++ b/lib/apollo-federation/has_directives.rb
@@ -2,11 +2,20 @@
 
 module ApolloFederation
   module HasDirectives
-    attr_reader :federation_directives
-
     def add_directive(name:, arguments: nil)
-      @federation_directives ||= []
-      @federation_directives << { name: name, arguments: arguments }
+      own_federation_directives << { name: name, arguments: arguments }
+    end
+
+    def federation_directives
+      if is_a?(Class) && superclass.respond_to?(:federation_directives)
+        own_federation_directives + superclass.federation_directives
+      else
+        own_federation_directives
+      end
+    end
+
+    def own_federation_directives
+      @own_federation_directives ||= []
     end
   end
 end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -22,7 +22,7 @@ module ApolloFederation
       end
 
       def federation_version
-        @federation_version || '1.0'
+        @federation_version || (superclass.respond_to?(:federation_version) && superclass.federation_version) || '1.0'
       end
 
       def federation_2?
@@ -38,7 +38,11 @@ module ApolloFederation
       end
 
       def link_namespace
-        @link[:as]
+        if @link
+          @link[:as]
+        elsif superclass.respond_to?(:link_namespace)
+          superclass.link_namespace
+        end
       end
 
       def query(new_query_object = nil)

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -22,7 +22,7 @@ module ApolloFederation
       end
 
       def federation_version
-        @federation_version || (superclass.respond_to?(:federation_version) && superclass.federation_version) || '1.0'
+        @federation_version || find_inherited_value(:federation_version, '1.0')
       end
 
       def federation_2?
@@ -38,11 +38,7 @@ module ApolloFederation
       end
 
       def link_namespace
-        if @link
-          @link[:as]
-        elsif superclass.respond_to?(:link_namespace)
-          superclass.link_namespace
-        end
+        @link ? @link[:as] : find_inherited_value(:link_namespace)
       end
 
       def query(new_query_object = nil)

--- a/spec/apollo-federation/service_field_v1_spec.rb
+++ b/spec/apollo-federation/service_field_v1_spec.rb
@@ -459,7 +459,7 @@ RSpec.describe ApolloFederation::ServiceField do
       base_object_with_id = Class.new(base_object) do
         key fields: 'id'
 
-        field :id, String, null: false
+        field :id, GraphQL::Types::ID, null: false
       end
 
       product = Class.new(base_object_with_id) do
@@ -473,7 +473,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           type Product @key(fields: "id") {
-            id: String!
+            id: ID!
           }
         GRAPHQL
       )

--- a/spec/apollo-federation/service_field_v1_spec.rb
+++ b/spec/apollo-federation/service_field_v1_spec.rb
@@ -455,6 +455,30 @@ RSpec.describe ApolloFederation::ServiceField do
       )
     end
 
+    it 'returns SDL that inherits object directives' do
+      base_object_with_id = Class.new(base_object) do
+        key fields: 'id'
+
+        field :id, String, null: false
+      end
+
+      product = Class.new(base_object_with_id) do
+        graphql_name 'Product'
+      end
+
+      schema = Class.new(base_schema) do
+        orphan_types product
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+        <<~GRAPHQL,
+          type Product @key(fields: "id") {
+            id: String!
+          }
+        GRAPHQL
+      )
+    end
+
     context 'with context in schema generation' do
       let(:schema) do
         product = Class.new(base_object) do

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -1539,6 +1539,50 @@ RSpec.describe ApolloFederation::ServiceField do
       )
     end
 
+    it 'returns SDL that inherits object directives' do
+      base_object_with_id = Class.new(base_object) do
+        key fields: 'id'
+
+        field :id, String, null: false
+      end
+
+      product = Class.new(base_object_with_id) do
+        graphql_name 'Product'
+      end
+
+      schema = Class.new(base_schema) do
+        federation version: '2.0'
+        orphan_types product
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+        <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+
+          type Product @federation__key(fields: "id") {
+            id: String!
+          }
+        GRAPHQL
+      )
+    end
+
+    it 'returns SDL that inherits schema directives' do
+      new_base_schema = Class.new(base_schema) do
+        federation version: '2.0', link: { as: 'fed2' }
+      end
+
+      schema = Class.new(new_base_schema)
+
+      expect(execute_sdl(schema)).to match_sdl(
+        <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+
+        GRAPHQL
+      )
+    end
+
     context 'with context in schema generation' do
       let(:schema) do
         product = Class.new(base_object) do


### PR DESCRIPTION
This PR adds inheritance of federation directives for consistency with graphql-ruby's native directives and other parts of their API like `field`, `field_class`, etc. Code like this is now supported:

```ruby
class RemotelyReferenceableObject < SalsifyGraphQL::Server::BaseObject
  key fields: 'id'
  field :id, ID, null: false
end

class BlogType < RemotelyReferenceableObject
  field :text, String, null: false
end

class BaseSchema <  GraphQL::Schema
  include ApolloFederation::Schema
  federation version: '2.0'
end

class MySchema < BaseSchema
  # ...
end
```