### PR TITLE
fix: Fix context passed to GraphQL::Schema.federation_sdl

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 appraise 'graphql-1.9' do
-  gem 'graphql', '1.9.8'
+  gem 'graphql', '1.9.21'
 end
 
 appraise 'graphql-1.10' do
-  gem 'graphql', '1.10.10'
+  gem 'graphql', '1.10.14'
 end
 
 appraise 'graphql-1.11' do

--- a/gemfiles/graphql_1.10.gemfile
+++ b/gemfiles/graphql_1.10.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "graphql", "1.10.10"
+gem "graphql", "1.10.14"
 
 gemspec path: "../"

--- a/gemfiles/graphql_1.10.gemfile.lock
+++ b/gemfiles/graphql_1.10.gemfile.lock
@@ -43,7 +43,7 @@ GEM
     diff-lcs (1.3)
     erubi (1.9.0)
     google-protobuf (3.13.0)
-    graphql (1.10.10)
+    graphql (1.10.14)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -114,7 +114,7 @@ DEPENDENCIES
   apollo-federation!
   appraisal
   debase
-  graphql (= 1.10.10)
+  graphql (= 1.10.14)
   pry-byebug
   rack
   rake

--- a/gemfiles/graphql_1.9.gemfile
+++ b/gemfiles/graphql_1.9.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "graphql", "1.9.8"
+gem "graphql", "1.9.21"
 
 gemspec path: "../"

--- a/gemfiles/graphql_1.9.gemfile.lock
+++ b/gemfiles/graphql_1.9.gemfile.lock
@@ -43,7 +43,7 @@ GEM
     diff-lcs (1.3)
     erubi (1.9.0)
     google-protobuf (3.13.0)
-    graphql (1.9.8)
+    graphql (1.9.21)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
@@ -114,7 +114,7 @@ DEPENDENCIES
   apollo-federation!
   appraisal
   debase
-  graphql (= 1.9.8)
+  graphql (= 1.9.21)
   pry-byebug
   rack
   rake

--- a/lib/apollo-federation/service_field.rb
+++ b/lib/apollo-federation/service_field.rb
@@ -19,7 +19,7 @@ module ApolloFederation
 
     def _service
       schema_class = context.schema.is_a?(GraphQL::Schema) ? context.schema.class : context.schema
-      { sdl: schema_class.federation_sdl(context: context) }
+      { sdl: schema_class.federation_sdl(context: context.to_h) }
     end
   end
 end


### PR DESCRIPTION
This fixes a problem where `ApolloFederation::ServiceField#_service` passed a `context` of type `GraphQL::Query::Context` rather than `Hash` which violates the contract of [GraphQL::Language::DocumentFromSchemaDefinition#initialize](https://github.com/rmosolgo/graphql-ruby/blob/master/lib/graphql/language/document_from_schema_definition.rb#L9). The API of `GraphQL::Query::Context` and `Hash` are similar enough that this didn't cause any problems until graphql-ruby 1.9.17 with the introduction of [context scoping](https://github.com/rmosolgo/graphql-ruby/pull/2634). After that change, calling `to_h`, `fetch` or `dig` on the context from anywhere in the resolution of `ApolloFederation::ServiceField#_service` (e.g. schema visibility checks) would result in a ` NoMethodError: undefined method `merge' for #<Query::Context ...>`.