### PR TITLE
feat: Snake case field references

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,19 @@ Call `key` within your class definition:
 
 ```ruby
 class User < BaseObject
-  key fields: 'id'
+  key fields: :id
 end
 ```
+
+Compound keys are also supported:
+
+```ruby
+class User < BaseObject
+  key fields: [:id, { organization: :id }]
+end
+```
+
+See [field set syntax](#field-set-syntax) for more details on the format of the `fields` option.
 
 ### The `@external` directive
 
@@ -131,9 +141,11 @@ Pass the `requires:` option to your field definition:
 class Product < BaseObject
   field :price, Int, null: true, external: true
   field :weight, Int, null: true, external: true
-  field :shipping_estimate, Int, null: true, requires: { fields: "price weight"}
+  field :shipping_estimate, Int, null: true, requires: { fields: [:price, :weight] }
 end
 ```
+
+See [field set syntax](#field-set-syntax) for more details on the format of the `fields` option.
 
 ### The `@provides` directive
 
@@ -143,8 +155,24 @@ Pass the `provides:` option to your field definition:
 
 ```ruby
 class Review < BaseObject
-  field :author, 'User', null: true, provides: { fields: 'username' }
+  field :author, 'User', null: true, provides: { fields: :username }
 end
+```
+See [field set syntax](#field-set-syntax) for more details on the format of the `fields` option.
+
+### Field set syntax
+
+Field sets can be either strings encoded with the Apollo Field Set [syntax]((https://www.apollographql.com/docs/apollo-server/federation/federation-spec/#scalar-_fieldset)) or arrays, hashes and snake case symbols that follow the graphql-ruby conventions:
+
+```ruby
+# Equivalent to the "organizationId" field set
+:organization_id
+
+# Equivalent to the "price weight" field set
+[:price, :weight]
+
+# Equivalent to the "id organization { id }" field set
+[:id, { organization: :id }]
 ```
 
 ### Reference resolvers

--- a/example/accounts.rb
+++ b/example/accounts.rb
@@ -28,7 +28,7 @@ USERS = [
 ].freeze
 
 class User < BaseObject
-  key fields: 'id'
+  key fields: :id
 
   field :id, ID, null: false
   field :name, String, null: true

--- a/example/inventory.rb
+++ b/example/inventory.rb
@@ -18,13 +18,13 @@ INVENTORY = [
 
 class Product < BaseObject
   extend_type
-  key fields: 'upc'
+  key fields: :upc
 
   field :upc, String, null: false, external: true
   field :weight, Int, null: true, external: true
   field :price, Int, null: true, external: true
   field :in_stock, Boolean, null: true
-  field :shipping_estimate, Int, null: true, requires: { fields: 'price weight' }
+  field :shipping_estimate, Int, null: true, requires: { fields: %i[price weight] }
 
   def self.resolve_reference(reference, _context)
     reference.merge(INVENTORY.find { |product| product[:upc] == reference[:upc] })

--- a/example/products.rb
+++ b/example/products.rb
@@ -35,7 +35,7 @@ PRODUCTS = [
 ].freeze
 
 class Product < BaseObject
-  key fields: 'upc'
+  key fields: :upc
 
   field :upc, String, null: false
   field :name, String, null: true

--- a/example/reviews.rb
+++ b/example/reviews.rb
@@ -53,11 +53,11 @@ USERNAMES = [
 ].freeze
 
 class Review < BaseObject
-  key fields: 'id'
+  key fields: :id
 
   field :id, ID, null: false
   field :body, String, null: true
-  field :author, 'User', null: true, provides: { fields: 'username' }
+  field :author, 'User', null: true, provides: { fields: :username }
   field :product, 'Product', null: true
 
   def author
@@ -66,7 +66,7 @@ class Review < BaseObject
 end
 
 class User < BaseObject
-  key fields: 'id'
+  key fields: :id
   extend_type
 
   field :id, ID, null: false, external: true
@@ -84,7 +84,7 @@ class User < BaseObject
 end
 
 class Product < BaseObject
-  key fields: 'upc'
+  key fields: :upc
   extend_type
 
   field :upc, String, null: false, external: true

--- a/lib/apollo-federation/field.rb
+++ b/lib/apollo-federation/field.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'apollo-federation/field_set_serializer'
 require 'apollo-federation/has_directives'
 
 module ApolloFederation
@@ -15,7 +16,7 @@ module ApolloFederation
           name: 'requires',
           arguments: [
             name: 'fields',
-            values: requires[:fields],
+            values: ApolloFederation::FieldSetSerializer.serialize(requires[:fields]),
           ],
         )
       end
@@ -24,7 +25,7 @@ module ApolloFederation
           name: 'provides',
           arguments: [
             name: 'fields',
-            values: provides[:fields],
+            values: ApolloFederation::FieldSetSerializer.serialize(provides[:fields]),
           ],
         )
       end

--- a/lib/apollo-federation/field_set_serializer.rb
+++ b/lib/apollo-federation/field_set_serializer.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'graphql'
+
+module ApolloFederation
+  module FieldSetSerializer
+    extend self
+
+    def serialize(fields)
+      case fields
+      when Hash
+        fields.map do |field, nested_selections|
+          "#{camelize(field)} { #{serialize(nested_selections)} }"
+        end.join(' ')
+      when Array
+        fields.map do |field|
+          serialize(field)
+        end.join(' ')
+      when String
+        fields
+      when Symbol
+        camelize(fields)
+      else
+        raise ArgumentError, "Unexpected field set type: #{fields.class}"
+      end
+    end
+
+    private
+
+    def camelize(field)
+      GraphQL::Schema::Member::BuildType.camelize(field.to_s)
+    end
+  end
+end

--- a/lib/apollo-federation/interface.rb
+++ b/lib/apollo-federation/interface.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'apollo-federation/field_set_serializer'
 require 'apollo-federation/has_directives'
 
 module ApolloFederation
@@ -22,7 +23,7 @@ module ApolloFederation
           name: 'key',
           arguments: [
             name: 'fields',
-            values: fields,
+            values: ApolloFederation::FieldSetSerializer.serialize(fields),
           ],
         )
       end

--- a/lib/apollo-federation/object.rb
+++ b/lib/apollo-federation/object.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'apollo-federation/field_set_serializer'
 require 'apollo-federation/has_directives'
 
 module ApolloFederation
@@ -20,7 +21,7 @@ module ApolloFederation
           name: 'key',
           arguments: [
             name: 'fields',
-            values: fields,
+            values: ApolloFederation::FieldSetSerializer.serialize(fields),
           ],
         )
       end

--- a/spec/apollo-federation/entities_field_spec.rb
+++ b/spec/apollo-federation/entities_field_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ApolloFederation::EntitiesField do
       let(:type_with_key) do
         Class.new(base_object) do
           graphql_name 'TypeWithKey'
-          key fields: 'id'
+          key fields: :id
           field :id, 'ID', null: false
           field :other_field, 'String', null: true
         end
@@ -215,7 +215,7 @@ RSpec.describe ApolloFederation::EntitiesField do
                 let(:type_with_key) do
                   Class.new(base_object) do
                     graphql_name 'TypeWithKey'
-                    key fields: 'id'
+                    key fields: :id
                     field :id, 'ID', null: false
                     field :other_field, 'String', null: false
 
@@ -266,7 +266,7 @@ RSpec.describe ApolloFederation::EntitiesField do
 
                     Class.new(base_object) do
                       graphql_name 'TypeWithKey'
-                      key fields: 'id'
+                      key fields: :id
                       field :id, 'ID', null: false
                       field :other_field, 'String', null: false
 

--- a/spec/apollo-federation/field_set_serializer_spec.rb
+++ b/spec/apollo-federation/field_set_serializer_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'apollo-federation/field_set_serializer'
+
+RSpec.describe ApolloFederation::FieldSetSerializer do
+  it 'serializes symbols' do
+    expect(
+      described_class.serialize(:id),
+    ).to eql('id')
+  end
+
+  it 'serializes snake case symbols as lower camelcase' do
+    expect(
+      described_class.serialize(:product_id),
+    ).to eql('productId')
+  end
+
+  it 'serializes arrays of symbols' do
+    expect(
+      described_class.serialize(%i[qualifier id]),
+    ).to eql('qualifier id')
+  end
+
+  it 'serializes nested selections' do
+    expect(
+      described_class.serialize([:id, organization: :id]),
+    ).to eql('id organization { id }')
+  end
+
+  it 'serializes strings without modification' do
+    expect(
+      described_class.serialize('product_id'),
+    ).to eql('product_id')
+  end
+end

--- a/spec/apollo-federation/service_field_spec.rb
+++ b/spec/apollo-federation/service_field_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe ApolloFederation::ServiceField do
       it 'returns valid SDL for @key directives' do
         product = Class.new(base_object) do
           graphql_name 'Product'
-          key fields: 'upc'
+          key fields: :upc
 
           field :upc, String, null: false
         end
@@ -250,7 +250,7 @@ RSpec.describe ApolloFederation::ServiceField do
       it 'returns valid SDL for @key directives' do
         product = Class.new(base_object) do
           graphql_name 'Product'
-          key fields: 'upc'
+          key fields: :upc
 
           field :upc, String, null: false
         end
@@ -272,8 +272,8 @@ RSpec.describe ApolloFederation::ServiceField do
     it 'returns valid SDL for multiple @key directives' do
       product = Class.new(base_object) do
         graphql_name 'Product'
-        key fields: 'upc'
-        key fields: 'name'
+        key fields: :upc
+        key fields: :name
 
         field :upc, String, null: false
         field :name, String, null: true
@@ -297,7 +297,7 @@ RSpec.describe ApolloFederation::ServiceField do
       product = Class.new(base_object) do
         graphql_name 'Product'
         extend_type
-        key fields: 'upc'
+        key fields: :upc
 
         field :upc, String, null: false, external: true
         field :price, Integer, null: true
@@ -321,7 +321,7 @@ RSpec.describe ApolloFederation::ServiceField do
       product = Class.new(base_object) do
         graphql_name 'Product'
         extend_type
-        key fields: 'upc'
+        key fields: :upc
 
         field :upc, String, null: false, external: true
         field :price, Integer, null: true
@@ -329,10 +329,10 @@ RSpec.describe ApolloFederation::ServiceField do
 
       review = Class.new(base_object) do
         graphql_name 'Review'
-        key fields: 'id'
+        key fields: :id
 
         field :id, 'ID', null: false
-        field :product, product, provides: { fields: 'upc' }, null: true
+        field :product, product, provides: { fields: :upc }, null: true
       end
 
       schema = Class.new(base_schema) do
@@ -358,12 +358,12 @@ RSpec.describe ApolloFederation::ServiceField do
       product = Class.new(base_object) do
         graphql_name 'Product'
         extend_type
-        key fields: 'upc'
+        key fields: :upc
 
         field :upc, String, null: false, external: true
         field :weight, Integer, null: true, external: true
         field :price, Integer, null: true, external: true
-        field :shipping_estimate, Integer, null: true, requires: { fields: 'price weight' }
+        field :shipping_estimate, Integer, null: true, requires: { fields: %i[price weight] }
       end
 
       schema = Class.new(base_schema) do


### PR DESCRIPTION
This is an awesome library but one of the things I initially found confusing was the naming differences between graphql-ruby fields (snake case symbols) and apollo-federation-ruby field references (lower camelcase) e.g.

```ruby
class Order < BaseObject
  field :zip_code, String, null: true, external: true
  field :weight, Int, null: true, external: true
  field :shipping_estimate, Int, null: true, requires: { fields: 'zipCode weight' }
end
```

This PR updates field set arguments to be either strings which follow the Apollo syntax or arrays, hashes and snake case symbols that follow the graphql-ruby conventions e.g.

```ruby
class Order < BaseObject
  field :zip_code, String, null: true, external: true
  field :weight, Int, null: true, external: true
  field :shipping_estimate, Int, null: true, requires: { fields: [:zip_code, :weight] }
end
```
Supporting the existing string syntax makes the change backwards compatible and it also provides an escape hatch for advanced use cases like directives/arguments in field selections or not wanting camelization.
 
Fixes #36