### PR TITLE
fix(tracing): breaking deprecation for using attach trace to result

### DIFF
--- a/lib/apollo-federation/tracing.rb
+++ b/lib/apollo-federation/tracing.rb
@@ -16,9 +16,11 @@ module ApolloFederation
     end
 
     # @deprecated There is no need to call this method. Traces are added to the result automatically
-    def attach_trace_to_result(_result)
+    def attach_trace_to_result(result)
       warn '[DEPRECATION] `attach_trace_to_result` is deprecated. There is no need to call it, as '\
         'traces are added to the result automatically'
+
+      result.to_h
     end
   end
 end


### PR DESCRIPTION
https://github.com/Gusto/apollo-federation-ruby/commit/a1c2a41d3d01f06364d439cdcc273f4678fed7bd

This was a breaking change released with a patch version. Was that intentional?