### PR TITLE
fix(tracing): headers recognition in Rails apps

### DIFF
--- a/lib/apollo-federation/tracing.rb
+++ b/lib/apollo-federation/tracing.rb
@@ -4,6 +4,10 @@ module ApolloFederation
   module Tracing
     KEY = :ftv1
     DEBUG_KEY = "#{KEY}_debug".to_sym
+    EXPECTED_HEADERS = [
+      'apollo-federation-include-trace',
+      'HTTP_APOLLO_FEDERATION_INCLUDE_TRACE',
+    ].freeze
 
     module_function
 
@@ -12,7 +16,7 @@ module ApolloFederation
     end
 
     def should_add_traces(headers)
-      headers && headers['apollo-federation-include-trace'] == KEY.to_s
+      headers&.values_at(*EXPECTED_HEADERS)&.any?(KEY.to_s)
     end
 
     # @deprecated There is no need to call this method. Traces are added to the result automatically

--- a/spec/apollo-federation/tracing_spec.rb
+++ b/spec/apollo-federation/tracing_spec.rb
@@ -562,6 +562,34 @@ RSpec.describe ApolloFederation::Tracing do
     end
   end
 
+  RSpec.shared_examples 'properly recognizes "include tracing" headers' do
+    describe '"include traces" headers recognition' do
+      subject { described_class.should_add_traces(headers) }
+
+      context 'with a general request header' do
+        let(:headers) do
+          { 'apollo-federation-include-trace' => ApolloFederation::Tracing::KEY.to_s }
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context 'with a Rails-transformed request header' do
+        let(:headers) do
+          { 'HTTP_APOLLO_FEDERATION_INCLUDE_TRACE' => ApolloFederation::Tracing::KEY.to_s }
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context 'without any of the headers' do
+        let(:headers) { {} }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
+
   context 'with the legacy runtime' do
     let(:base_schema) do
       Class.new(GraphQL::Schema) do
@@ -570,6 +598,7 @@ RSpec.describe ApolloFederation::Tracing do
     end
 
     it_behaves_like 'a basic tracer'
+    it_behaves_like 'properly recognizes "include tracing" headers'
   end
 
   context 'with the new interpreter' do
@@ -582,5 +611,6 @@ RSpec.describe ApolloFederation::Tracing do
     end
 
     it_behaves_like 'a basic tracer'
+    it_behaves_like 'properly recognizes "include tracing" headers'
   end
 end


### PR DESCRIPTION
Inside a Ruby on Rails application custom request headers are transformed by uppercasing and prepending the `HTTP_` prefix before it reaches the application controller. This causes the `should_add_traces` method to not recognize the incoming `apollo-federation-include-trace` header properly. 

This is a simple fix that would properly return `true` for both the original and transformed header.

Rails API reference: https://github.com/rails/rails/blob/5f3ff60084ab5d5921ca3499814e4697f8350ee7/actionpack/lib/action_dispatch/http/headers.rb#L126