### PR TITLE
fix(tracing): Support google-protobuf gem v3.15.3 and up

### DIFF
--- a/lib/apollo-federation/object.rb
+++ b/lib/apollo-federation/object.rb
@@ -8,6 +8,10 @@ module ApolloFederation
       klass.extend(ClassMethods)
     end
 
+    def self.new
+      ::Object.new
+    end
+
     module ClassMethods
       include HasDirectives
 


### PR DESCRIPTION
This fixes https://github.com/Gusto/apollo-federation-ruby/issues/121. 

Somehow after `google-protobuf` v3.15.3, when `ApolloFederation::Tracing::Node.new` is called, it evaluates to `ApolloFederation::Object.new` instead of `::Object.new`. So deferring to `::Object.new` in `ApolloFederation::Tracing::Node.new` fixes the error.