### PR TITLE
fix: allow the federation schema to be a subclass of the standard schema

### DIFF
--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -73,7 +73,7 @@ module ApolloFederation
           @orig_query_object = new_query_object
         else
           if !@federation_query_object
-            @federation_query_object = federation_query(@orig_query_object)
+            @federation_query_object = federation_query(@orig_query_object || super)
             @federation_query_object.define_entities_field(schema_entities)
 
             super(@federation_query_object)

--- a/spec/apollo-federation/entities_field_spec.rb
+++ b/spec/apollo-federation/entities_field_spec.rb
@@ -363,19 +363,21 @@ RSpec.describe ApolloFederation::EntitiesField do
     end
   end
 
-  context 'when the federation schema is a subclass of the base schema' do
-    final_schema = lambda do |schema|
-      Class.new(schema) do
-        include ApolloFederation::Schema
+  if Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('1.10.0')
+    context 'when the federation schema is a subclass of the base schema' do
+      final_schema = lambda do |schema|
+        Class.new(schema) do
+          include ApolloFederation::Schema
+        end
       end
-    end
 
-    it_behaves_like 'entities field', final_schema do
-      let(:base_schema) do
-        Class.new(GraphQL::Schema) do
-          if Gem::Version.new(GraphQL::VERSION) < Gem::Version.new('1.12.0')
-            use GraphQL::Execution::Interpreter
-            use GraphQL::Analysis::AST
+      it_behaves_like 'entities field', final_schema do
+        let(:base_schema) do
+          Class.new(GraphQL::Schema) do
+            if Gem::Version.new(GraphQL::VERSION) < Gem::Version.new('1.12.0')
+              use GraphQL::Execution::Interpreter
+              use GraphQL::Analysis::AST
+            end
           end
         end
       end


### PR DESCRIPTION
i.e., allow something like:

    class MySchema < GraphQL::Schema
      query MyQuery
    end

    class MyFederationSchema < MySchema
      include ApolloFederation::Schema
    end

this pattern is useful if you want to host both a federation subgraph
_and_ a "first-class" data graph with the same schema minus the
federation extensions.

this didn't work before this change, because `MyFederationSchema` never
gets `query MyQuery` called on it, so it doesn't know about the
provided Query object.

the changes in the specs from subclassing `base_schema` to re-opening
and modifying it aren't necessary, but i think better reflect real-world
usage -- people probably don't subclass an empty base schema and then
add `query`, `mutation`, etc. to it, they just add those things to the
schema class itself.