### PR TITLE
feat: Remove erronous? lock to x86_64-linux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     apollo-federation (1.1.5)
-      google-protobuf (~> 3.7)
+      google-protobuf (~> 3.13.0)
       graphql (>= 1.9.8)
 
 GEM
@@ -42,7 +42,7 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.3)
     erubi (1.9.0)
-    google-protobuf (3.13.0-x86_64-linux)
+    google-protobuf (3.13.0)
     graphql (1.10.10)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -124,4 +124,4 @@ DEPENDENCIES
   ruby-debug-ide
 
 BUNDLED WITH
-   2.1.4
+   2.3.4

--- a/apollo-federation.gemspec
+++ b/apollo-federation.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'graphql', '>= 1.9.8'
 
-  spec.add_runtime_dependency 'google-protobuf', '~> 3.7'
+  spec.add_runtime_dependency 'google-protobuf', '~> 3.13.0'
 
   spec.add_development_dependency 'actionpack'
   spec.add_development_dependency 'appraisal'


### PR DESCRIPTION
# What's up? 

Hoping this will resolve #144 , where it seems like folks using M1 might have issue with the platform being forced to use the linux binary. Also updates bundler to the latest/greatest, which keeps turning up when you search for M1 compatibility issues, though not directly related to this one. 

Hopefully the bundler update accounts for the fact there are multiple mac platform types better. 

This platform change was introduced by semantic release bot in https://github.com/Gusto/apollo-federation-ruby/commit/631ebfe4bf4fb2d4097f6322be321b8814755234#diff-89cade48462044ee1b672dc5f4c3ec250fbd29effcd8932096a23c1283c6731fR44 which could be a bundler bug :shrug: