### PR TITLE
chore: configure semantic release for main branch

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -22,4 +22,5 @@ module.exports = {
     ],
     '@semantic-release/github',
   ],
+  branches: ['main'],
 };


### PR DESCRIPTION
main is not included in its list of default branches