### PR TITLE
fix: Bump protobuf to 3.19 and lock on minor version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     apollo-federation (2.0.0)
-      google-protobuf (~> 3.13.0)
+      google-protobuf (~> 3.19)
       graphql (>= 1.10.14)
 
 GEM
@@ -42,7 +42,7 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.3)
     erubi (1.9.0)
-    google-protobuf (3.13.0-x86_64-linux)
+    google-protobuf (3.19.3)
     graphql (1.10.14)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)

--- a/apollo-federation.gemspec
+++ b/apollo-federation.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'graphql', '>= 1.10.14'
 
-  spec.add_runtime_dependency 'google-protobuf', '~> 3.13.0'
+  spec.add_runtime_dependency 'google-protobuf', '~> 3.19'
 
   spec.add_development_dependency 'actionpack'
   spec.add_development_dependency 'appraisal'

--- a/gemfiles/graphql_1.10.gemfile.lock
+++ b/gemfiles/graphql_1.10.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     apollo-federation (2.0.0)
-      google-protobuf (~> 3.13.0)
+      google-protobuf (~> 3.19)
       graphql (>= 1.10.14)
 
 GEM
@@ -42,7 +42,7 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.3)
     erubi (1.9.0)
-    google-protobuf (3.13.0)
+    google-protobuf (3.19.3)
     graphql (1.10.14)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)

--- a/gemfiles/graphql_1.11.gemfile.lock
+++ b/gemfiles/graphql_1.11.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     apollo-federation (2.0.0)
-      google-protobuf (~> 3.13.0)
+      google-protobuf (~> 3.19)
       graphql (>= 1.10.14)
 
 GEM
@@ -42,7 +42,7 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.4.4)
     erubi (1.9.0)
-    google-protobuf (3.13.0)
+    google-protobuf (3.19.3)
     graphql (1.11.2)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)

--- a/gemfiles/graphql_1.12.gemfile.lock
+++ b/gemfiles/graphql_1.12.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     apollo-federation (2.0.0)
-      google-protobuf (~> 3.13.0)
+      google-protobuf (~> 3.19)
       graphql (>= 1.10.14)
 
 GEM
@@ -42,7 +42,7 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.4.4)
     erubi (1.9.0)
-    google-protobuf (3.13.0)
+    google-protobuf (3.19.3)
     graphql (1.12.5)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
1. In https://github.com/Gusto/apollo-federation-ruby/pull/150, the intention was to remove the platform lock. In that PR, `google-protobuf` was locked to `3.13.x` as per the gemspec and specs. 

2. However in reality, consumers could have been installing `3.19.x` which I think is very common. We should relax the lock to minor version which lets people bump to the latest minor version. 

3. But I've also bumped the requirement to `~> 3.19` because of this [CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569) 

This should result in a bump to `2.1.0` and that should be alright because of point 2 and if you're locked to below protobuf `3.19`, the major release should guard that 