### PR TITLE
fix: Update to latest CircleCI Ruby 2.6.x image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
       appraisal:
         type: string
     docker:
-      - image: circleci/ruby:2.6-node
+      - image: cimg/ruby:2.6.9-node
     environment:
       BUNDLE_APP_CONFIG: .bundle
     steps:
@@ -74,7 +74,7 @@ jobs:
       appraisal:
         type: string
     docker:
-      - image: circleci/ruby:2.6-node
+      - image: cimg/ruby:2.6.9-node
     environment:
       BUNDLE_APP_CONFIG: .bundle
     steps:
@@ -87,7 +87,7 @@ jobs:
       - run: yarn lint
   release:
     docker:
-      - image: circleci/ruby:2.6-node
+      - image: cimg/ruby:2.6.9-node
     steps:
       - checkout
       - bundle-install


### PR DESCRIPTION
# What's up?

Not gonna lie, 50% of the motivation of the PR is to trigger a release 😸 . In the previous one, the `fix` message was in the PR title but not in the commit, which I think doesn't trigger a release. 

Since our ruby image is really old, I thought it's at least a good task to upgrade it to the latest of the 2.6 series.

https://circleci.com/developer/images/image/cimg/ruby