### PR TITLE
build: Bump cache version to fix failing main build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,16 +15,16 @@ commands:
       - restore_cache:
           name: Restore Ruby Package Cache
           keys:
-            - v2-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - v2-gem-cache-{{ arch }}-{{ .Branch }}-
-            - v2-gem-cache-{{ arch }}-
+            - v3-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - v3-gem-cache-{{ arch }}-{{ .Branch }}-
+            - v3-gem-cache-{{ arch }}-
       - run:
           name: Install base Ruby dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path=vendor/bundle
       - save_cache:
           name: Save Ruby Package Cache
-          key: v2-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: v3-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - ./vendor/bundle
   appraisal-install:
@@ -39,16 +39,16 @@ commands:
       - restore_cache:
           name: Restore Appraisal package cache
           keys:
-            - v2-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
-            - v2-gem-cache-{{ arch }}-{{ .Branch }}-
-            - v2-gem-cache-{{ arch }}-
+            - v3-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
+            - v3-gem-cache-{{ arch }}-{{ .Branch }}-
+            - v3-gem-cache-{{ arch }}-
       - run:
           name: Install appraisal dependencies
           command: |
             bundle exec appraisal << parameters.appraisal >> bundle install --jobs=4 --retry=3 --path=../vendor/bundle
       - save_cache:
           name: Save Appraisal package cache
-          key: v2-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
+          key: v3-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
           paths:
             - ./vendor/bundle
 


### PR DESCRIPTION
# What's up? 

The main build [failed](https://app.circleci.com/pipelines/github/Gusto/apollo-federation-ruby/469/workflows/a0756cc1-5622-46e8-b7af-bf4979f6cb70/jobs/2532) . Guessing it's the cache version. 

This PR bumps the cache version manually. 

## Follow ups 
PRs like this pollute the history, especially when the problem is temporary, if the cache gets invalidated (15 days?), the build would have passed. Let's investigate if we can: 

1. Also base the cache on the image version 
2. And have a manual bump control that's based on an ENV variable 

Will open an issue for it if it's indeed a cache issue. 