### PR TITLE
fix: Use `bundle install` to avoid `bundle check` that changes our lockfiles

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.3)
     erubi (1.9.0)
-    google-protobuf (3.19.3-x86_64-linux)
+    google-protobuf (3.19.3)
     graphql (1.10.14)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)

--- a/gemfiles/graphql_1.11.gemfile.lock
+++ b/gemfiles/graphql_1.11.gemfile.lock
@@ -42,7 +42,7 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.4.4)
     erubi (1.9.0)
-    google-protobuf (3.19.3-x86_64-linux)
+    google-protobuf (3.19.3)
     graphql (1.11.2)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)

--- a/release.config.js
+++ b/release.config.js
@@ -6,7 +6,7 @@ module.exports = {
     [
       'semantic-release-rubygem',
       {
-        updateGemfileLock: 'bundle exec appraisal install',
+        updateGemfileLock: 'bundle exec appraisal bundle install',
       },
     ],
     [


### PR DESCRIPTION
# What's up? 

This is a stopgap solution to #169.

When we run `appraisal install`, it does a `bundle check || bundle install`. This is probably an optimization to avoid bundling if our local gems satisfy the needed dependencies. 

However, there seems to be some issue with `bundle check` that's causing it to alter our `gemfiles` to a platform specific version. See the Rubygems issue in #169. 

For now, let's use `bundle install` so this doesn't happen. 

**Self note: REMEMBER to prefix commit to cut a fix release**