### PR TITLE
fix: Attempt to remove platform specific lock on google-protobuf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
       - run:
           name: Install base Ruby dependencies
           command: |
-            bundle install --jobs=4 --retry=3 --path=vendor/bundle
+            bundle install --jobs=1 --retry=3 --path=vendor/bundle
       - save_cache:
           name: Save Ruby Package Cache
           key: v4-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
@@ -45,7 +45,7 @@ commands:
       - run:
           name: Install appraisal dependencies
           command: |
-            bundle exec appraisal << parameters.appraisal >> bundle install --jobs=4 --retry=3 --path=../vendor/bundle
+            bundle exec appraisal << parameters.appraisal >> bundle install --jobs=1 --retry=3 --path=../vendor/bundle
       - save_cache:
           name: Save Appraisal package cache
           key: v4-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,16 +15,16 @@ commands:
       - restore_cache:
           name: Restore Ruby Package Cache
           keys:
-            - v3-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - v3-gem-cache-{{ arch }}-{{ .Branch }}-
-            - v3-gem-cache-{{ arch }}-
+            - v4-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - v4-gem-cache-{{ arch }}-{{ .Branch }}-
+            - v4-gem-cache-{{ arch }}-
       - run:
           name: Install base Ruby dependencies
           command: |
             bundle install --jobs=4 --retry=3 --path=vendor/bundle
       - save_cache:
           name: Save Ruby Package Cache
-          key: v3-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: v4-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - ./vendor/bundle
   appraisal-install:
@@ -39,16 +39,16 @@ commands:
       - restore_cache:
           name: Restore Appraisal package cache
           keys:
-            - v3-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
-            - v3-gem-cache-{{ arch }}-{{ .Branch }}-
-            - v3-gem-cache-{{ arch }}-
+            - v4-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
+            - v4-gem-cache-{{ arch }}-{{ .Branch }}-
+            - v4-gem-cache-{{ arch }}-
       - run:
           name: Install appraisal dependencies
           command: |
             bundle exec appraisal << parameters.appraisal >> bundle install --jobs=4 --retry=3 --path=../vendor/bundle
       - save_cache:
           name: Save Appraisal package cache
-          key: v3-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
+          key: v4-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
           paths:
             - ./vendor/bundle
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,16 +15,16 @@ commands:
       - restore_cache:
           name: Restore Ruby Package Cache
           keys:
-            - v4-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - v4-gem-cache-{{ arch }}-{{ .Branch }}-
-            - v4-gem-cache-{{ arch }}-
+            - v5-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - v5-gem-cache-{{ arch }}-{{ .Branch }}-
+            - v5-gem-cache-{{ arch }}-
       - run:
           name: Install base Ruby dependencies
           command: |
             bundle install --jobs=1 --retry=3 --path=vendor/bundle
       - save_cache:
           name: Save Ruby Package Cache
-          key: v4-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: v5-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - ./vendor/bundle
   appraisal-install:
@@ -39,16 +39,16 @@ commands:
       - restore_cache:
           name: Restore Appraisal package cache
           keys:
-            - v4-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
-            - v4-gem-cache-{{ arch }}-{{ .Branch }}-
-            - v4-gem-cache-{{ arch }}-
+            - v5-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
+            - v5-gem-cache-{{ arch }}-{{ .Branch }}-
+            - v5-gem-cache-{{ arch }}-
       - run:
           name: Install appraisal dependencies
           command: |
             bundle exec appraisal << parameters.appraisal >> bundle install --jobs=1 --retry=3 --path=../vendor/bundle
       - save_cache:
           name: Save Appraisal package cache
-          key: v4-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
+          key: v5-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "current_appraisal.gemfile.lock" }}
           paths:
             - ./vendor/bundle
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.3)
     erubi (1.9.0)
-    google-protobuf (3.19.3-x86_64-linux)
+    google-protobuf (3.19.4)
     graphql (1.10.14)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
# What's up? 

Last attempt to see if this fixes the platform locking issue when semantic bot commits. 

Everytime we release an update with `fix`, it adds to the changelog :( 

Was hoping the fix would help confirm the issue for https://github.com/rubygems/rubygems/issues/5325 too.  If this doesn't work, I'll wait for the issue and also figure out how to run semantic bot locally or on Circle without publishing for debugging. 