### PR TITLE
fix: remove InstanceDefinable reference

### DIFF
--- a/gemfiles/graphql_2.0.gemfile.lock
+++ b/gemfiles/graphql_2.0.gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: ..
   specs:
-    apollo-federation (2.2.0)
+    apollo-federation (2.2.1)
       google-protobuf (~> 3.19)
-      graphql (>= 2.0)
+      graphql (>= 1.10.14)
 
 GEM
   remote: https://rubygems.org/
@@ -115,7 +115,7 @@ DEPENDENCIES
   apollo-federation!
   appraisal
   debase
-  graphql (~> 1.13.6)
+  graphql (~> 2.0)
   pry-byebug
   rack
   rake

--- a/lib/apollo-federation/federated_document_from_schema_definition.rb
+++ b/lib/apollo-federation/federated_document_from_schema_definition.rb
@@ -56,8 +56,6 @@ module ApolloFederation
     def merge_directives(node, type)
       if type.is_a?(ApolloFederation::HasDirectives)
         directives = type.federation_directives
-      elsif type.is_a?(GraphQL::Define::InstanceDefinable)
-        directives = type.metadata[:federation_directives]
       else
         directives = []
       end


### PR DESCRIPTION
# What's up? 
`InstanceDefinable` is used for the old block based `define` syntax. It's been deprecated since `1.10`. Not sure why we're referencing it. 

https://github.com/rmosolgo/graphql-ruby/pull/2680