### PR TITLE
fix: camelize string fields to match sym behavior

### DIFF
--- a/lib/apollo-federation/field.rb
+++ b/lib/apollo-federation/field.rb
@@ -16,7 +16,10 @@ module ApolloFederation
           name: 'requires',
           arguments: [
             name: 'fields',
-            values: ApolloFederation::FieldSetSerializer.serialize(requires[:fields]),
+            values: ApolloFederation::FieldSetSerializer.serialize(
+              requires[:fields],
+              camelize: requires.fetch(:camelize, true),
+            ),
           ],
         )
       end
@@ -25,7 +28,10 @@ module ApolloFederation
           name: 'provides',
           arguments: [
             name: 'fields',
-            values: ApolloFederation::FieldSetSerializer.serialize(provides[:fields]),
+            values: ApolloFederation::FieldSetSerializer.serialize(
+              provides[:fields],
+              camelize: provides.fetch(:camelize, true),
+            ),
           ],
         )
       end

--- a/lib/apollo-federation/field_set_serializer.rb
+++ b/lib/apollo-federation/field_set_serializer.rb
@@ -6,20 +6,18 @@ module ApolloFederation
   module FieldSetSerializer
     extend self
 
-    def serialize(fields)
+    def serialize(fields, camelize: true)
       case fields
       when Hash
         fields.map do |field, nested_selections|
-          "#{camelize(field)} { #{serialize(nested_selections)} }"
+          "#{camelize(field, camelize)} { #{serialize(nested_selections, camelize: camelize)} }"
         end.join(' ')
       when Array
         fields.map do |field|
-          serialize(field)
+          serialize(field, camelize: camelize)
         end.join(' ')
-      when String
-        fields
-      when Symbol
-        camelize(fields)
+      when Symbol, String
+        camelize(fields, camelize)
       else
         raise ArgumentError, "Unexpected field set type: #{fields.class}"
       end
@@ -27,8 +25,8 @@ module ApolloFederation
 
     private
 
-    def camelize(field)
-      GraphQL::Schema::Member::BuildType.camelize(field.to_s)
+    def camelize(field, camelize)
+      camelize ? GraphQL::Schema::Member::BuildType.camelize(field.to_s) : field.to_s
     end
   end
 end

--- a/lib/apollo-federation/interface.rb
+++ b/lib/apollo-federation/interface.rb
@@ -18,12 +18,12 @@ module ApolloFederation
         add_directive(name: 'extends')
       end
 
-      def key(fields:)
+      def key(fields:, camelize: true)
         add_directive(
           name: 'key',
           arguments: [
             name: 'fields',
-            values: ApolloFederation::FieldSetSerializer.serialize(fields),
+            values: ApolloFederation::FieldSetSerializer.serialize(fields, camelize: camelize),
           ],
         )
       end

--- a/lib/apollo-federation/object.rb
+++ b/lib/apollo-federation/object.rb
@@ -16,12 +16,12 @@ module ApolloFederation
         add_directive(name: 'extends')
       end
 
-      def key(fields:)
+      def key(fields:, camelize: true)
         add_directive(
           name: 'key',
           arguments: [
             name: 'fields',
-            values: ApolloFederation::FieldSetSerializer.serialize(fields),
+            values: ApolloFederation::FieldSetSerializer.serialize(fields, camelize: camelize),
           ],
         )
       end

--- a/spec/apollo-federation/field_set_serializer_spec.rb
+++ b/spec/apollo-federation/field_set_serializer_spec.rb
@@ -4,33 +4,71 @@ require 'spec_helper'
 require 'apollo-federation/field_set_serializer'
 
 RSpec.describe ApolloFederation::FieldSetSerializer do
-  it 'serializes symbols' do
-    expect(
-      described_class.serialize(:id),
-    ).to eql('id')
+  context 'when camelize is true' do
+    let(:camelize) { true }
+
+    it 'serializes symbols' do
+      expect(
+        described_class.serialize(:id, camelize: camelize),
+      ).to eql('id')
+    end
+
+    it 'serializes snake case symbols as lower camelcase' do
+      expect(
+        described_class.serialize(:product_id, camelize: camelize),
+      ).to eql('productId')
+    end
+
+    it 'serializes arrays of symbols' do
+      expect(
+        described_class.serialize(%i[qualifier id], camelize: camelize),
+      ).to eql('qualifier id')
+    end
+
+    it 'serializes nested selections' do
+      expect(
+        described_class.serialize([:id, organization: :id], camelize: camelize),
+      ).to eql('id organization { id }')
+    end
+
+    it 'serializes strings' do
+      expect(
+        described_class.serialize('product_id', camelize: camelize),
+      ).to eql('productId')
+    end
   end
 
-  it 'serializes snake case symbols as lower camelcase' do
-    expect(
-      described_class.serialize(:product_id),
-    ).to eql('productId')
-  end
+  context 'when camelize is false' do
+    let(:camelize) { false }
 
-  it 'serializes arrays of symbols' do
-    expect(
-      described_class.serialize(%i[qualifier id]),
-    ).to eql('qualifier id')
-  end
+    it 'serializes symbols' do
+      expect(
+        described_class.serialize(:id, camelize: camelize),
+      ).to eql('id')
+    end
 
-  it 'serializes nested selections' do
-    expect(
-      described_class.serialize([:id, organization: :id]),
-    ).to eql('id organization { id }')
-  end
+    it 'serializes snake case symbols without modification' do
+      expect(
+        described_class.serialize(:product_id, camelize: camelize),
+      ).to eql('product_id')
+    end
 
-  it 'serializes strings without modification' do
-    expect(
-      described_class.serialize('product_id'),
-    ).to eql('product_id')
+    it 'serializes arrays of symbols' do
+      expect(
+        described_class.serialize(%i[qualifier_id id], camelize: camelize),
+      ).to eql('qualifier_id id')
+    end
+
+    it 'serializes nested selections' do
+      expect(
+        described_class.serialize([:id, organization: :id], camelize: camelize),
+      ).to eql('id organization { id }')
+    end
+
+    it 'serializes strings without modification' do
+      expect(
+        described_class.serialize('product_id', camelize: camelize),
+      ).to eql('product_id')
+    end
   end
 end

--- a/spec/apollo-federation/service_field_spec.rb
+++ b/spec/apollo-federation/service_field_spec.rb
@@ -408,6 +408,7 @@ RSpec.describe ApolloFederation::ServiceField do
           extend_type
           key fields: :product_id, camelize: false
 
+          field :product_id, String, null: false, camelize: false
           field :options, [String], null: false, requires: { fields: 'my_id', camelize: false }
           field :other_options, [String], null: false, requires: { fields: 'my_id', camelize: true }
         end
@@ -421,6 +422,7 @@ RSpec.describe ApolloFederation::ServiceField do
             type Product @extends @key(fields: "product_id") {
               options: [String!]! @requires(fields: "my_id")
               otherOptions: [String!]! @requires(fields: "myId")
+              product_id: String!
             }
           GRAPHQL
         )

--- a/spec/apollo-federation/service_field_spec.rb
+++ b/spec/apollo-federation/service_field_spec.rb
@@ -380,6 +380,53 @@ RSpec.describe ApolloFederation::ServiceField do
       )
     end
 
+    describe 'camelize option' do
+      it 'camelizes by default' do
+        product = Class.new(base_object) do
+          graphql_name 'Product'
+          key fields: :product_id
+
+          field :product_id, String, null: false
+        end
+
+        schema = Class.new(base_schema) do
+          orphan_types product
+        end
+
+        expect(execute_sdl(schema)).to match_sdl(
+          <<~GRAPHQL,
+            type Product @key(fields: "productId") {
+              productId: String!
+            }
+          GRAPHQL
+        )
+      end
+
+      it 'serializes according to camelize option otherwise' do
+        product = Class.new(base_object) do
+          graphql_name 'Product'
+          extend_type
+          key fields: :product_id, camelize: false
+
+          field :options, [String], null: false, requires: { fields: 'my_id', camelize: false }
+          field :other_options, [String], null: false, requires: { fields: 'my_id', camelize: true }
+        end
+
+        schema = Class.new(base_schema) do
+          orphan_types product
+        end
+
+        expect(execute_sdl(schema)).to match_sdl(
+          <<~GRAPHQL,
+            type Product @extends @key(fields: "product_id") {
+              options: [String!]! @requires(fields: "my_id")
+              otherOptions: [String!]! @requires(fields: "myId")
+            }
+          GRAPHQL
+        )
+      end
+    end
+
     it 'returns SDL that honors visibility checks' do
       product = Class.new(base_object) do
         graphql_name 'Product'


### PR DESCRIPTION
Followup to a previous feature release, which intentionally did not camelize string inputs in order to preserve backwards compatibility. Here we are breaking compatibility to make the behavior consistent. Users can revert the behavior using the `camelize` option if it is necessary.

BREAKING CHANGE: string fields will be camelized by default rather than passed as is.