### PR TITLE
chore: revert add linux and darwin platforms to lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,9 +42,6 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.3)
     erubi (1.9.0)
-    google-protobuf (3.19.4)
-    google-protobuf (3.19.4-x86-linux)
-    google-protobuf (3.19.4-x86_64-darwin)
     google-protobuf (3.19.4-x86_64-linux)
     graphql (1.10.14)
     i18n (1.8.5)
@@ -58,14 +55,6 @@ GEM
     minitest (5.14.2)
     nokogiri (1.13.3)
       mini_portile2 (~> 2.8.0)
-      racc (~> 1.4)
-    nokogiri (1.13.3-aarch64-linux)
-      racc (~> 1.4)
-    nokogiri (1.13.3-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.3-x86-linux)
-      racc (~> 1.4)
-    nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     parallel (1.17.0)
     parser (2.6.3.0)
@@ -119,8 +108,6 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  darwin
-  linux
   ruby
 
 DEPENDENCIES


### PR DESCRIPTION
Reverts Gusto/apollo-federation-ruby#188

Just in case we cannot fix forward.