### PR TITLE
feat: introduce optional `resolve_references` method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ node_modules/
 .circleci/processed-config.yml
 
 .DS_Store
+.idea
+vendor

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ node_modules/
 .circleci/processed-config.yml
 
 .DS_Store
-.idea
-vendor

--- a/lib/apollo-federation/entities_field.rb
+++ b/lib/apollo-federation/entities_field.rb
@@ -52,8 +52,8 @@ module ApolloFederation
 
         results = results.map do |result|
           context.schema.after_lazy(result) do |resolved_value|
-            # TODO: This isn't 100% correct: if (for some reason) 2 different resolve_reference calls
-            # return the same object, it might not have the right type
+            # TODO: This isn't 100% correct: if (for some reason) 2 different resolve_reference
+            # calls return the same object, it might not have the right type
             # Right now, apollo-federation just adds a __typename property to the result,
             # but I don't really like the idea of modifying the resolved object
             context[resolved_value] = type

--- a/lib/apollo-federation/entities_field.rb
+++ b/lib/apollo-federation/entities_field.rb
@@ -27,8 +27,10 @@ module ApolloFederation
     end
 
     def _entities(representations:)
-      representations.map do |reference|
-        typename = reference[:__typename]
+      grouped_references = representations.group_by { |r| r[:__typename] }
+
+      final_results = []
+      grouped_references.each do |typename, references|
         # TODO: Use warden or schema?
         type = context.warden.get_type(typename)
         if type.nil? || type.kind != GraphQL::TypeKinds::OBJECT
@@ -40,21 +42,27 @@ module ApolloFederation
         # TODO: What if the type is an interface?
         type_class = class_of_type(type)
 
-        if type_class.respond_to?(:resolve_reference)
-          result = type_class.resolve_reference(reference, context)
+        if type_class.respond_to?(:resolve_references)
+          results = type_class.resolve_references(references, context)
+        elsif type_class.respond_to?(:resolve_reference)
+          results = references.map { |reference| type_class.resolve_reference(reference, context) }
         else
-          result = reference
+          results = references
         end
 
-        context.schema.after_lazy(result) do |resolved_value|
-          # TODO: This isn't 100% correct: if (for some reason) 2 different resolve_reference calls
-          # return the same object, it might not have the right type
-          # Right now, apollo-federation just adds a __typename property to the result,
-          # but I don't really like the idea of modifying the resolved object
-          context[resolved_value] = type
-          resolved_value
+        results = results.map do |result|
+          context.schema.after_lazy(result) do |resolved_value|
+            # TODO: This isn't 100% correct: if (for some reason) 2 different resolve_reference calls
+            # return the same object, it might not have the right type
+            # Right now, apollo-federation just adds a __typename property to the result,
+            # but I don't really like the idea of modifying the resolved object
+            context[resolved_value] = type
+            resolved_value
+          end
         end
+        final_results = final_results.concat(results)
       end
+      final_results
     end
 
     private

--- a/spec/apollo-federation/entities_field_spec.rb
+++ b/spec/apollo-federation/entities_field_spec.rb
@@ -215,7 +215,9 @@ RSpec.describe ApolloFederation::EntitiesField do
               end
 
               context 'when the type defines a resolve_references method' do
-                let(:representations) { [{ __typename: typename, id: id_1 }, { __typename: typename, id: id_2 }] }
+                let(:representations) do
+                  [{ __typename: typename, id: id_1 }, { __typename: typename, id: id_2 }]
+                end
                 let(:id_1) { 123 }
                 let(:id_2) { 456 }
 
@@ -232,7 +234,12 @@ RSpec.describe ApolloFederation::EntitiesField do
                   end
                 end
 
-                it { is_expected.to match_array [{ 'id' => id_1.to_s, 'otherField' => 'data!' }, { 'id' => id_2.to_s, 'otherField' => 'data2!' }] }
+                it {
+                  expect(subject).to match_array [
+                    { 'id' => id_1.to_s, 'otherField' => 'data!' },
+                    { 'id' => id_2.to_s, 'otherField' => 'data2!' },
+                  ]
+                }
                 it { expect(errors).to be_nil }
               end
 


### PR DESCRIPTION
This addresses the issues with using data loader in the existing `resolve_reference` method. (See: #205) 
By grouping all the references of the same type into a single call to `resolve_references` the records can more easily be loaded as a batch. This can be done using a data loader (`.load_all`) or just a direct DB query as all the references are provided in a single method call. 

The existing `resolve_reference` method is still supported but `resolve_references` will be the preferred approach. 
