### PR TITLE
fix: address SNYK-RUBY-GOOGLEPROTOBUF-3167775

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     apollo-federation (3.3.0)
-      google-protobuf (~> 3.19)
+      google-protobuf (~> 3.21.7)
       graphql (>= 1.10.14)
 
 GEM
@@ -42,7 +42,8 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.3)
     erubi (1.9.0)
-    google-protobuf (3.21.1-x86_64-linux)
+    google-protobuf (3.21.12-x86_64-darwin)
+    google-protobuf (3.21.12-x86_64-linux)
     graphql (1.10.14)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -106,6 +107,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/apollo-federation.gemspec
+++ b/apollo-federation.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'graphql', '>= 1.10.14'
 
-  spec.add_runtime_dependency 'google-protobuf', '~> 3.19'
+  spec.add_runtime_dependency 'google-protobuf', '~> 3.21.7'
 
   spec.add_development_dependency 'actionpack'
   spec.add_development_dependency 'appraisal'


### PR DESCRIPTION
This PR addresses the following identified security vulnerability: https://app.snyk.io/vuln/SNYK-RUBY-GOOGLEPROTOBUF-3167775