### PR TITLE
fix: import `@inaccessible` directive in Fed v2.3

### DIFF
--- a/lib/apollo-federation/federated_document_from_schema_definition.rb
+++ b/lib/apollo-federation/federated_document_from_schema_definition.rb
@@ -14,6 +14,7 @@ module ApolloFederation
       '_entities',
       '_service',
     ].freeze
+    INACCESSIBLE_DIRECTIVE = 'inaccessible'
 
     def build_object_type_node(object_type)
       object_node = super
@@ -70,7 +71,7 @@ module ApolloFederation
     end
 
     def directive_name(directive)
-      if schema.federation_2?
+      if schema.federation_2? && directive[:name] != INACCESSIBLE_DIRECTIVE
         "#{schema.link_namespace}__#{directive[:name]}"
       else
         directive[:name]

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -61,7 +61,7 @@ module ApolloFederation
 
         <<~SCHEMA
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace})
+            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace}, import: ["@inaccessible"])
 
         SCHEMA
       end

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product {
             upc: String!
@@ -144,7 +144,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends {
             upc: String!
@@ -180,7 +180,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Position @federation__shareable {
             x: Int!
@@ -217,9 +217,9 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
-          type Position @federation__inaccessible {
+          type Position @inaccessible {
             x: Int!
             y: Int!
           }
@@ -254,7 +254,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
             type Product @fed2__extends {
               upc: String!
@@ -290,7 +290,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
             type Position @fed2__shareable {
               x: Int!
@@ -327,9 +327,9 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
-            type Position @fed2__inaccessible {
+            type Position @inaccessible {
               x: Int!
               y: Int!
             }
@@ -363,7 +363,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
             type Product @fed2__key(fields: "upc") {
               upc: String!
@@ -394,7 +394,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
             type Product @fed2__extends @fed2__key(fields: "upc") {
               price: Int
@@ -421,7 +421,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible"])
 
             type Product @fed2__interfaceObject @fed2__key(fields: "id") {
               id: ID!
@@ -470,13 +470,13 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Book implements Product {
             upc: String!
           }
 
-          interface Product @federation__inaccessible {
+          interface Product @inaccessible {
             upc: String!
           }
         GRAPHQL
@@ -533,7 +533,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Book implements Product @federation__extends @federation__key(fields: "upc") {
             upc: String! @federation__external
@@ -573,7 +573,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
             type Product @federation__key(fields: "upc") {
               upc: String!
@@ -604,7 +604,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
             type Product @federation__key(fields: "upc") {
               upc: String!
@@ -632,7 +632,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__key(fields: "upc") @federation__key(fields: "name") {
             name: String
@@ -660,7 +660,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int
@@ -687,7 +687,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__interfaceObject @federation__key(fields: "id") {
             id: ID!
@@ -718,7 +718,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Position {
             x: Int! @federation__shareable
@@ -754,10 +754,10 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Position {
-            x: Int! @federation__inaccessible
+            x: Int! @inaccessible
             y: Int!
           }
 
@@ -786,7 +786,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends @federation__key(fields: "id") {
             id: ID!
@@ -822,7 +822,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int
@@ -857,7 +857,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             price: Int @federation__external
@@ -886,7 +886,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
             type Product @federation__key(fields: "productId") {
               productId: String!
@@ -914,7 +914,7 @@ RSpec.describe ApolloFederation::ServiceField do
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3")
+              @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
             type Product @federation__extends @federation__key(fields: "product_id") {
               options: [String!]! @federation__requires(fields: "my_id")
@@ -947,7 +947,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3")
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible"])
 
           type Product @federation__extends @federation__key(fields: "upc") {
             upc: String! @federation__external


### PR DESCRIPTION
### Description

Currently, due to different namespaces across multiple subgraphs, we are getting the following error:

```GraphQL
LINK_IMPORT_NAME_MISMATCH: The federation "@inaccessible" directive is imported with mismatched name between subgraphs: it is imported as "@federation__inaccessible" in subgraphs "A" and "B" but "@inaccessible" in subgraphs "C", "D"...
```

According to [prasek](https://github.com/prasek)'s comment [here](https://github.com/apollographql/federation/issues/1976#issuecomment-1184522540), we should always import the `@inaccessible` directive to avoid multiple namespaces. This PR address this.