### PR TITLE
chore: Bump google-protobuf dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     apollo-federation (3.6.0)
-      google-protobuf (~> 3.21.7)
+      google-protobuf (~> 3.22)
       graphql (>= 1.10.14)
 
 GEM
@@ -42,9 +42,7 @@ GEM
     debase-ruby_core_source (0.10.9)
     diff-lcs (1.3)
     erubi (1.9.0)
-    google-protobuf (3.21.12)
-    google-protobuf (3.21.12-x86_64-darwin)
-    google-protobuf (3.21.12-x86_64-linux)
+    google-protobuf (3.22.2)
     graphql (1.10.14)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -110,6 +108,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  ruby
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-darwin-22

--- a/apollo-federation.gemspec
+++ b/apollo-federation.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'graphql', '>= 1.10.14'
 
-  spec.add_runtime_dependency 'google-protobuf', '~> 3.21.7'
+  spec.add_runtime_dependency 'google-protobuf', '~> 3.22'
 
   spec.add_development_dependency 'actionpack'
   spec.add_development_dependency 'appraisal'


### PR DESCRIPTION
google-protobuf 3.21 does not support ruby 3.2.0