### PR TITLE
ci: fix release by only running bundle install w/o appraisal during publish

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -6,7 +6,7 @@ module.exports = {
     [
       'semantic-release-rubygem',
       {
-        updateGemfileLock: 'bundle exec appraisal bundle install',
+        updateGemfileLock: 'bundle install',
       },
     ],
     [


### PR DESCRIPTION
# Changes
- Sets semantic release bundle command to a plain ol' `bundle install`