### PR TITLE
chore: update google-protobuf to 3.22.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: .
   specs:
     apollo-federation (3.6.1)
-      google-protobuf (~> 3.21.7)
+      google-protobuf (~> 3.22)
       graphql (>= 1.10.14)
 
 GEM
@@ -47,7 +47,9 @@ GEM
     debase-ruby_core_source (3.2.0)
     diff-lcs (1.5.0)
     erubi (1.12.0)
-    google-protobuf (3.21.12)
+    google-protobuf (3.22.2-arm64-darwin)
+    google-protobuf (3.22.2-x86_64-darwin)
+    google-protobuf (3.22.2-x86_64-linux)
     graphql (2.0.19)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)

--- a/apollo-federation.gemspec
+++ b/apollo-federation.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'graphql', '>= 1.10.14'
 
-  spec.add_runtime_dependency 'google-protobuf', '~> 3.21.7'
+  spec.add_runtime_dependency 'google-protobuf', '~> 3.22'
 
   spec.add_development_dependency 'actionpack'
   spec.add_development_dependency 'appraisal'


### PR DESCRIPTION
# Changes
- Updates `google-protobuf` to 3.22.x, which supports Ruby 3.2

Co-authored-by @such

Closes https://github.com/Gusto/apollo-federation-ruby/pull/231
