### PR TITLE
fix: ensure correct ordering of `resolve_references`

### DIFF
--- a/lib/apollo-federation/entities_field.rb
+++ b/lib/apollo-federation/entities_field.rb
@@ -29,8 +29,7 @@ module ApolloFederation
     def _entities(representations:)
       grouped_references = representations.group_by { |r| r[:__typename] }
 
-      final_results = []
-      grouped_references.each do |typename, references|
+      grouped_references.flat_map do |typename, references|
         # TODO: Use warden or schema?
         type = context.warden.get_type(typename)
         if type.nil? || type.kind != GraphQL::TypeKinds::OBJECT
@@ -50,7 +49,7 @@ module ApolloFederation
           results = references
         end
 
-        results = results.map do |result|
+        results.map do |result|
           context.schema.after_lazy(result) do |resolved_value|
             # TODO: This isn't 100% correct: if (for some reason) 2 different resolve_reference
             # calls return the same object, it might not have the right type
@@ -60,9 +59,7 @@ module ApolloFederation
             resolved_value
           end
         end
-        final_results = final_results.concat(results)
       end
-      final_results
     end
 
     private

--- a/lib/apollo-federation/entities_field.rb
+++ b/lib/apollo-federation/entities_field.rb
@@ -27,9 +27,9 @@ module ApolloFederation
     end
 
     def _entities(representations:)
-      grouped_references = representations.group_by { |r| r[:__typename] }
+      chunked_references = representations.chunk { |r| r[:__typename] }
 
-      grouped_references.flat_map do |typename, references|
+      chunked_references.flat_map do |typename, references|
         # TODO: Use warden or schema?
         type = context.warden.get_type(typename)
         if type.nil? || type.kind != GraphQL::TypeKinds::OBJECT


### PR DESCRIPTION
Hello!

I ran into this bug a couple weeks ago. It took me a little while to find the cause of this fix, but this seems to be working well for us.

The first commit is a stylistic change—I'm happy to revert it. The second commit demonstrates the failing case, and the last fixes it. I wrote a detailed description of the change in the final commit as well.

I do know that this solution is a little less efficient than the previous version. Theoretically, if there is a request asking for _N_ entities of `[TypeA, TypeB, TypeA, TypeB, TypeA, TypeB, ...]`, this would result in _N_ calls to `resolve_references`.

I'm quite sure that it would be possible to make this almost as efficient as before (I mean, 1 call to `resolve_references` per distinct type). However, I'd like to consider that out of scope of this PR for now.

<details>
<summary>Additional details from last commit message</summary>

    Fix ordering of entities returned via `.resolve_references`
    
    The previous implementation incorrectly shuffled the order of entities
    when different `__typename`s were requested and interleaved.
    
    Here are some examples:
    
    ```
    working_case_1 = [ # all of one type
      { __typename: typename, id: 1 },
      { __typename: typename, id: 2 },
      { __typename: typename, id: 3 },
    ]
    
    working_case_2 = [ # not interleaved
      { __typename: typename, id: 1 },
      { __typename: typename, id: 2 },
      { __typename: another_typename, id: 3 },
      { __typename: another_typename, id: 4 },
    ]
    
    broken_case = [ # interleaved
      { __typename: typename, id: 1 },
      { __typename: typename, id: 2 },
      { __typename: another_typename, id: 3 },
      { __typename: another_typename, id: 4 },
      { __typename: typename, id: 5 },
    ]
    ```
    
    The `broken_case` example would likely return a response where the IDs
    are `[1, 2, 5, 3, 4]`, that is, the all of `typename`s first, then
    followed by all `another_typename`s. However, the correct response would
    be one that returns IDs in the order of `[1, 2, 3, 4, 5]`, exactly as
    requested.
    
    This is problematic because Apollo Federation joins responses
    together only by the order of those responses. If any response is out of
    order, then the final response would also be out of order.
    
    Whereas the broken implementation would have called each type's
    `resolve_references` only once, this commit's implementation will now
    call it once per type's "chunk" or "consecutive streak".

</details>