### PR TITLE
fix: inherit Query type from schema superclass

### DIFF
--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -46,7 +46,7 @@ module ApolloFederation
           @orig_query_object = new_query_object
         else
           if !@federation_query_object
-            @federation_query_object = federation_query(@orig_query_object)
+            @federation_query_object = federation_query(original_query)
             @federation_query_object.define_entities_field(schema_entities)
 
             super(@federation_query_object)
@@ -57,6 +57,10 @@ module ApolloFederation
       end
 
       private
+
+      def original_query
+        @orig_query_object || find_inherited_value(:original_query)
+      end
 
       def federation_2_prefix
         federation_namespace = ", as: \"#{link_namespace}\"" if link_namespace != DEFAULT_LINK_NAMESPACE

--- a/spec/apollo-federation/service_field_v1_spec.rb
+++ b/spec/apollo-federation/service_field_v1_spec.rb
@@ -479,6 +479,39 @@ RSpec.describe ApolloFederation::ServiceField do
       )
     end
 
+    it 'returns SDL that inherits the query type' do
+      product = Class.new(base_object) do
+        graphql_name 'Product'
+        extend_type
+
+        field :upc, String, null: false
+      end
+
+      query_obj = Class.new(base_object) do
+        graphql_name 'Query'
+
+        field :product, product, null: true
+      end
+
+      new_base_schema = Class.new(base_schema) do
+        query query_obj
+      end
+
+      schema = Class.new(new_base_schema)
+
+      expect(execute_sdl(schema)).to match_sdl(
+        <<~GRAPHQL,
+          type Product @extends {
+            upc: String!
+          }
+
+          type Query {
+            product: Product
+          }
+        GRAPHQL
+      )
+    end
+
     context 'with context in schema generation' do
       let(:schema) do
         product = Class.new(base_object) do

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -1946,6 +1946,43 @@ RSpec.describe ApolloFederation::ServiceField do
       )
     end
 
+    it 'returns SDL that inherits the query type' do
+      product = Class.new(base_object) do
+        graphql_name 'Product'
+        extend_type
+
+        field :upc, String, null: false
+      end
+
+      query_obj = Class.new(base_object) do
+        graphql_name 'Query'
+
+        field :product, product, null: true
+      end
+
+      new_base_schema = Class.new(base_schema) do
+        federation version: '2.0', link: { as: 'fed2' }
+        query query_obj
+      end
+
+      schema = Class.new(new_base_schema)
+
+      expect(execute_sdl(schema)).to match_sdl(
+        <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+
+          type Product @fed2__extends {
+            upc: String!
+          }
+
+          type Query {
+            product: Product
+          }
+        GRAPHQL
+      )
+    end
+
     context 'with context in schema generation' do
       let(:schema) do
         product = Class.new(base_object) do


### PR DESCRIPTION
This PR fixes `ApolloFederation::Schema` to properly inherit the `Query` type from any superclasses so code like the following works as expected:

```ruby
class BaseSchema < GraphQL::Schema
  include ApolloFederation::Schema
  query QueryType
end

class MySchema < BaseSchema
  # ...
end
```
We use this subclassing pattern quite a bit in tests to avoid mutating our "real" schema class.