### PR TITLE
feat: add resolvable argument to key annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ class User < BaseObject
 end
 ```
 
+As well as non-resolvable keys:
+
+```ruby
+class User < BaseObject
+  key fields: :id, resolvable: false
+end
+```
+
 See [field set syntax](#field-set-syntax) for more details on the format of the `fields` option.
 
 ### The `@external` directive

--- a/lib/apollo-federation/object.rb
+++ b/lib/apollo-federation/object.rb
@@ -35,7 +35,7 @@ module ApolloFederation
       def key(fields:, camelize: true, resolvable: true)
         arguments = [
           name: 'fields',
-          values: ApolloFederation::FieldSetSerializer.serialize(fields, camelize: camelize)
+          values: ApolloFederation::FieldSetSerializer.serialize(fields, camelize: camelize),
         ]
         arguments.append(name: 'resolvable', values: resolvable) unless resolvable
         add_directive(

--- a/lib/apollo-federation/object.rb
+++ b/lib/apollo-federation/object.rb
@@ -32,13 +32,15 @@ module ApolloFederation
         add_directive(name: 'tag', arguments: [name: 'name', values: name])
       end
 
-      def key(fields:, camelize: true)
+      def key(fields:, camelize: true, resolvable: true)
+        arguments = [
+          name: 'fields',
+          values: ApolloFederation::FieldSetSerializer.serialize(fields, camelize: camelize)
+        ]
+        arguments.append(name: 'resolvable', values: resolvable) unless resolvable
         add_directive(
           name: 'key',
-          arguments: [
-            name: 'fields',
-            values: ApolloFederation::FieldSetSerializer.serialize(fields, camelize: camelize),
-          ],
+          arguments: arguments,
         )
       end
     end


### PR DESCRIPTION
This adds support for federation 2.0's new [resolvable field](https://www.apollographql.com/docs/federation/federation-2/new-in-federation-2/#changes-to-key).

This was referred to [here](https://github.com/Gusto/apollo-federation-ruby/issues/217), but I never saw a fix for it, so here it is.