### PR TITLE
fix(tracer): add support for multiplex

### DIFF
--- a/lib/apollo-federation/tracing/tracer.rb
+++ b/lib/apollo-federation/tracing/tracer.rb
@@ -88,7 +88,7 @@ module ApolloFederation
         if query
           record_trace_end_time(query)
         elsif multiplex
-          multiplex.queries.each {|query| record_trace_end_time(query)}
+          multiplex.queries.each { |q| record_trace_end_time(q) }
         end
 
         result
@@ -96,6 +96,7 @@ module ApolloFederation
 
       def self.record_trace_end_time(query)
         return unless query.context && query.context[:tracing_enabled]
+
         trace = query.context.namespace(ApolloFederation::Tracing::KEY)
 
         trace.merge!(

--- a/spec/apollo-federation/tracing_spec.rb
+++ b/spec/apollo-federation/tracing_spec.rb
@@ -49,6 +49,35 @@ RSpec.describe ApolloFederation::Tracing do
         result = schema.execute('{ test }', context: { tracing_enabled: true, debug_tracing: true })
         expect(result[:extensions][:ftv1_debug]).not_to be_nil
       end
+
+      context 'with a multiplex query' do
+        it 'does not add tracing extension by default' do
+          result = schema.multiplex([
+            {query: '{ test }'},
+            {query: '{ test }'},
+            {query: '{ test }'}
+          ]).first
+          expect(result[:extensions]).to be_nil
+        end
+
+        it 'adds the extensions.ftv1 when the context has tracing_enabled: true' do
+          result = schema.multiplex([
+            {query: '{ test }', context: { tracing_enabled: true }},
+            {query: '{ test }', context: { tracing_enabled: true }},
+            {query: '{ test }', context: { tracing_enabled: true }}
+          ]).first
+          expect(result[:extensions][:ftv1]).not_to be_nil
+        end
+
+        it 'adds debugging info when the context has debug_tracing: true' do
+          result = schema.multiplex([
+            {query: '{ test }', context: { tracing_enabled: true, debug_tracing: true }},
+            {query: '{ test }', context: { tracing_enabled: true, debug_tracing: true }},
+            {query: '{ test }', context: { tracing_enabled: true, debug_tracing: true }}
+          ]).first
+          expect(result[:extensions][:ftv1_debug]).not_to be_nil
+        end
+      end
     end
 
     def trace(query)

--- a/spec/apollo-federation/tracing_spec.rb
+++ b/spec/apollo-federation/tracing_spec.rb
@@ -52,29 +52,35 @@ RSpec.describe ApolloFederation::Tracing do
 
       context 'with a multiplex query' do
         it 'does not add tracing extension by default' do
-          result = schema.multiplex([
-            {query: '{ test }'},
-            {query: '{ test }'},
-            {query: '{ test }'}
-          ]).first
+          result = schema.multiplex(
+            [
+              { query: '{ test }' },
+              { query: '{ test }' },
+              { query: '{ test }' },
+            ],
+          ).first
           expect(result[:extensions]).to be_nil
         end
 
         it 'adds the extensions.ftv1 when the context has tracing_enabled: true' do
-          result = schema.multiplex([
-            {query: '{ test }', context: { tracing_enabled: true }},
-            {query: '{ test }', context: { tracing_enabled: true }},
-            {query: '{ test }', context: { tracing_enabled: true }}
-          ]).first
+          result = schema.multiplex(
+            [
+              { query: '{ test }', context: { tracing_enabled: true } },
+              { query: '{ test }', context: { tracing_enabled: true } },
+              { query: '{ test }', context: { tracing_enabled: true } },
+            ],
+          ).first
           expect(result[:extensions][:ftv1]).not_to be_nil
         end
 
         it 'adds debugging info when the context has debug_tracing: true' do
-          result = schema.multiplex([
-            {query: '{ test }', context: { tracing_enabled: true, debug_tracing: true }},
-            {query: '{ test }', context: { tracing_enabled: true, debug_tracing: true }},
-            {query: '{ test }', context: { tracing_enabled: true, debug_tracing: true }}
-          ]).first
+          result = schema.multiplex(
+            [
+              { query: '{ test }', context: { tracing_enabled: true, debug_tracing: true } },
+              { query: '{ test }', context: { tracing_enabled: true, debug_tracing: true } },
+              { query: '{ test }', context: { tracing_enabled: true, debug_tracing: true } },
+            ],
+          ).first
           expect(result[:extensions][:ftv1_debug]).not_to be_nil
         end
       end


### PR DESCRIPTION
Fixes https://github.com/Gusto/apollo-federation-ruby/issues/197

We found that once we implemented tracing, multiplex queries would fail with only a `NoMethodError (undefined method 'context' for nil:NilClass)`

In debugging I found that multiplex queries end up hitting `Tracer.execute_query_lazy` which was expecting a single query at `data[:query]`, which was `nil` when `data[:multiplex].queries` included more than one query. 

This PR adds support for either a single query or several queries as in a multiplex context. 