### PR TITLE
fix: call `resolve_references` once per `__typename`

### DIFF
--- a/spec/apollo-federation/entities_field_spec.rb
+++ b/spec/apollo-federation/entities_field_spec.rb
@@ -327,6 +327,13 @@ RSpec.describe ApolloFederation::EntitiesField do
                       ],
                     )
                   end
+
+                  it 'calls resolve_references once per __typename' do
+                    allow(type_with_key).to receive(:resolve_references).and_call_original
+                    allow(another_type_with_key).to receive(:resolve_references).and_call_original
+                    subject
+                    expect([type_with_key, another_type_with_key]).to all have_received(:resolve_references).once
+                  end
                 end
               end
 


### PR DESCRIPTION
This PR is a follow up to #239.

The previous implementation called `resolve_references` once per contiguous `__typename` to ensure the correct ordering of the response. This could have resulted in wildly varying runtime efficiencies. A request calling for _N_ unique types across _M_ entities could have as little as _N_ queries or as many as _M_ queries, depending on if the entities happened to be in large groups of the same type or very interleaved.

By keeping track of the requested representations and their original indices, we can rebuild the response in the correct order even if things get shuffled during computation.