### PR TITLE
fix: visibility checks should handle duplicate types and fields

### DIFF
--- a/lib/apollo-federation/federated_document_from_schema_definition.rb
+++ b/lib/apollo-federation/federated_document_from_schema_definition.rb
@@ -69,7 +69,7 @@ module ApolloFederation
     def build_type_definition_nodes(types)
       non_federation_types = types.select do |type|
         if query_type?(type)
-          !type.fields.values.all? { |field| FEDERATION_QUERY_FIELDS.include?(field.graphql_name) }
+          !warden.fields(type).all? { |field| FEDERATION_QUERY_FIELDS.include?(field.graphql_name) }
         else
           !FEDERATION_TYPES.include?(type.graphql_name)
         end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -81,9 +81,9 @@ module ApolloFederation
 
         # Walk through all of the types and determine which ones are entities (any type with a
         # "key" directive)
-        types_schema.types.values.select do |type|
+        types_schema.send(:non_introspection_types).values.flatten.select do |type|
           # TODO: Interfaces can have a key...
-          !type.introspection? && type.include?(ApolloFederation::Object) &&
+          type.include?(ApolloFederation::Object) &&
             type.federation_directives&.any? { |directive| directive[:name] == 'key' }
         end
       end

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -2043,6 +2043,76 @@ RSpec.describe ApolloFederation::ServiceField do
         )
       end
     end
+
+    if Gem::Version.new(GraphQL::VERSION) >= Gem::Version.new('1.13.0')
+      context 'with visibility checks on types and fields with duplicate names' do
+        let(:schema) do
+          regular_product = Class.new(base_object) do
+            graphql_name 'Product'
+            key fields: :upc
+
+            field :upc, String, null: false
+            field :regular_field, String, null: true
+
+            def self.visible?(context)
+              context[:graph_type] == :regular
+            end
+          end
+
+          admin_product = Class.new(base_object) do
+            graphql_name 'Product'
+            key fields: :upc
+
+            field :upc, String, null: false
+            field :admin_field, String, null: true
+
+            def self.visible?(context)
+              context[:graph_type] == :admin
+            end
+          end
+
+          query_obj = Class.new(base_object) do
+            graphql_name 'Query'
+
+            field :hello, String, null: false
+
+            field :product, regular_product, null: true do
+              def visible?(context)
+                context[:graph_type] == :regular
+              end
+            end
+
+            field :product, admin_product, null: true do
+              def visible?(context)
+                context[:graph_type] == :admin
+              end
+            end
+          end
+
+          Class.new(base_schema) do
+            query query_obj
+          end
+        end
+
+        it 'applies visibility checks during SDL generation' do
+          results = schema.execute('{ _service { sdl } }', context: { graph_type: :regular })
+
+          expect(results.dig('data', '_service', 'sdl')).to match_sdl(
+            <<~GRAPHQL,
+              type Product @key(fields: "upc") {
+                regularField: String
+                upc: String!
+              }
+
+              type Query {
+                hello: String!
+                product: Product
+              }
+            GRAPHQL
+          )
+        end
+      end
+    end
   end
 
   if Gem::Version.new(GraphQL::VERSION) < Gem::Version.new('1.12.0')

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -2094,13 +2094,31 @@ RSpec.describe ApolloFederation::ServiceField do
           end
         end
 
-        it 'applies visibility checks during SDL generation' do
+        it 'applies visibility checks during SDL generation to expose schema members' do
           results = schema.execute('{ _service { sdl } }', context: { graph_type: :regular })
 
           expect(results.dig('data', '_service', 'sdl')).to match_sdl(
             <<~GRAPHQL,
               type Product @key(fields: "upc") {
                 regularField: String
+                upc: String!
+              }
+
+              type Query {
+                hello: String!
+                product: Product
+              }
+            GRAPHQL
+          )
+        end
+
+        it 'applies visibility checks during SDL generation to expose alternate schema members' do
+          results = schema.execute('{ _service { sdl } }', context: { graph_type: :admin })
+
+          expect(results.dig('data', '_service', 'sdl')).to match_sdl(
+            <<~GRAPHQL,
+              type Product @key(fields: "upc") {
+                adminField: String
                 upc: String!
               }
 


### PR DESCRIPTION
This PR fixes two visibility scenarios that graphql-ruby supports but apollo-federation-ruby's does not:

1. Multiple object types with the same name as long as only one is visible at runtime
2. Multiple fields with the same name as long as only one is visible at runtime

The first scenario was broken because visibility checking in [GraphQL::Schema.types](https://github.com/rmosolgo/graphql-ruby/blob/3a548f8cb540f16f09506bde9fc0778d3eba276d/lib/graphql/schema.rb#L286) was applied when generating the `_Entity` union but we don't have a properly setup context at this point, resulting in either a `GraphQL::Schema::DuplicateNamesError` or a `NoMethodError: undefined method 'introspection?' for nil:NilClass` depending on how an application has setup their visibility checks for types with the same name. The fix is to avoid any visibility checks when generating the `_Entity` union and leave it up to the graphql-ruby runtime to apply visibility checks during query execution when we have a proper context.

The second scenario was broken because the federation SDL generation was looking at all of a type's fields rather than just its visible fields resulting in `GraphQL::Schema::DuplicateNamesError`. The fix is to use warden to only look at the visible fields.