### PR TITLE
fix: include inherited types in generated _Entity union

### DIFF
--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -77,7 +77,7 @@ module ApolloFederation
         types_schema = Class.new(self)
         # Add the original query objects to the types. We have to use orphan_types here to avoid
         # infinite recursion
-        types_schema.orphan_types(@orig_query_object)
+        types_schema.orphan_types(original_query)
 
         # Walk through all of the types and determine which ones are entities (any type with a
         # "key" directive)


### PR DESCRIPTION
This fixes the generated `_Entity` union to include members inherited from a schema superclass. I missed this in the original fix for #241.