### PR TITLE
Add support for @composeDirective

### DIFF
--- a/lib/apollo-federation/federated_document_from_schema_definition.rb
+++ b/lib/apollo-federation/federated_document_from_schema_definition.rb
@@ -101,7 +101,7 @@ module ApolloFederation
 
     def directive_name(directive)
       if schema.federation_2? && !Schema::IMPORTED_DIRECTIVES.include?(directive[:name])
-        "#{schema.link_namespace}__#{directive[:name]}"
+        "#{schema.default_link_namespace}__#{directive[:name]}"
       else
         directive[:name]
       end

--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -8,6 +8,7 @@ require 'apollo-federation/federated_document_from_schema_definition.rb'
 module ApolloFederation
   module Schema
     IMPORTED_DIRECTIVES = ['inaccessible', 'tag'].freeze
+    IMPORTED_DIRECTIVES_V2_1 = ['composeDirective'].freeze
 
     def self.included(klass)
       klass.extend(CommonMethods)
@@ -16,9 +17,16 @@ module ApolloFederation
     module CommonMethods
       DEFAULT_LINK_NAMESPACE = 'federation'
 
-      def federation(version: '1.0', link: {})
+      def federation(version: '1.0', default_link_namespace: nil, links: [], compose_directives: [])
         @federation_version = version
-        @link = { as: DEFAULT_LINK_NAMESPACE }.merge(link)
+        @default_link_namespace = default_link_namespace
+        @links = links
+
+        if !federation_2_1? && compose_directives.any?
+          raise ArgumentError, 'composeDirective is available in Federation 2.1 and later'
+        end
+
+        @compose_directives = compose_directives
       end
 
       def federation_version
@@ -29,6 +37,10 @@ module ApolloFederation
         Gem::Version.new(federation_version.to_s) >= Gem::Version.new('2.0.0')
       end
 
+      def federation_2_1?
+        Gem::Version.new(federation_version.to_s) >= Gem::Version.new('2.1.0')
+      end
+
       def federation_sdl(context: nil)
         document_from_schema = FederatedDocumentFromSchemaDefinition.new(self, context: context)
 
@@ -37,8 +49,8 @@ module ApolloFederation
         output
       end
 
-      def link_namespace
-        @link ? @link[:as] : find_inherited_value(:link_namespace)
+      def default_link_namespace
+        @default_link_namespace || find_inherited_value(:default_link_namespace, DEFAULT_LINK_NAMESPACE)
       end
 
       def query(new_query_object = nil)
@@ -62,14 +74,44 @@ module ApolloFederation
         @orig_query_object || find_inherited_value(:original_query)
       end
 
+      def compose_directives
+        @compose_directives || find_inherited_value(:compose_directives, [])
+      end
+
+      def links
+        @links || find_inherited_value(:links, [])
+      end
+
+      def all_links
+        imported_directives = IMPORTED_DIRECTIVES
+        imported_directives += IMPORTED_DIRECTIVES_V2_1 if federation_2_1?
+        default_link = {
+          url: 'https://specs.apollo.dev/federation/v2.3',
+          import: imported_directives,
+        }
+        default_link[:as] = default_link_namespace if default_link_namespace != DEFAULT_LINK_NAMESPACE
+        [default_link, *links]
+      end
+
       def federation_2_prefix
-        federation_namespace = ", as: \"#{link_namespace}\"" if link_namespace != DEFAULT_LINK_NAMESPACE
+        schema = ['extend schema']
 
-        <<~SCHEMA
-          extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3"#{federation_namespace}, import: [#{(IMPORTED_DIRECTIVES.map { |directive| "\"@#{directive}\"" }).join(', ')}])
+        all_links.each do |link|
+          link_str = "  @link(url: \"#{link[:url]}\""
+          link_str += ", as: \"#{link[:as]}\"" if link[:as]
+          link_str += ", import: [#{link[:import].map { |d| "\"@#{d}\"" }.join(', ')}]" if link[:import]
+          link_str += ')'
+          schema << link_str
+        end
 
-        SCHEMA
+        compose_directives.each do |directive|
+          schema << "  @composeDirective(name: \"@#{directive}\")"
+        end
+
+        schema << ''
+        schema << ''
+
+        schema.join("\n")
       end
 
       def schema_entities

--- a/spec/apollo-federation/service_field_v2_spec.rb
+++ b/spec/apollo-federation/service_field_v2_spec.rb
@@ -128,6 +128,98 @@ RSpec.describe ApolloFederation::ServiceField do
       )
     end
 
+    it 'returns the federation SDL with multiple links for the schema' do
+      product = Class.new(base_object) do
+        graphql_name 'Product'
+
+        field :upc, String, null: false
+      end
+
+      query_obj = Class.new(base_object) do
+        graphql_name 'Query'
+
+        field :product, product, null: true
+      end
+
+      schema = Class.new(base_schema) do
+        query query_obj
+        federation version: '2.3',
+                   links: [{
+                     url: 'https://specs.example.com/federation/v2.3',
+                     import: ['test'],
+                   }]
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+        <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@composeDirective"])
+            @link(url: "https://specs.example.com/federation/v2.3", import: ["@test"])
+
+          type Product {
+            upc: String!
+          }
+
+          type Query {
+            product: Product
+          }
+        GRAPHQL
+      )
+    end
+
+    it 'returns the federation SDL with compose directives for the schema' do
+      complexity_directive = Class.new(GraphQL::Schema::Directive) do
+        graphql_name 'complexity'
+        argument :fixed, Integer
+        description 'complexity of the field'
+        locations GraphQL::Schema::Directive::FIELD_DEFINITION
+      end
+
+      product = Class.new(base_object) do
+        graphql_name 'Product'
+
+        field :upc, String, null: false
+      end
+
+      query_obj = Class.new(base_object) do
+        graphql_name 'Query'
+
+        field :product, product, null: true, directives: { complexity_directive => { fixed: 1 } }
+      end
+
+      schema = Class.new(base_schema) do
+        query query_obj
+        federation version: '2.3',
+                   links: [{
+                     url: 'https://specs.example.com/federation/v2.3',
+                     import: [complexity_directive.graphql_name],
+                   }],
+                   compose_directives: [complexity_directive.graphql_name]
+      end
+
+      expect(execute_sdl(schema)).to match_sdl(
+        <<~GRAPHQL,
+          extend schema
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@composeDirective"])
+            @link(url: "https://specs.example.com/federation/v2.3", import: ["@complexity"])
+            @composeDirective(name: "@complexity")
+
+          """
+          complexity of the field
+          """
+          directive @complexity(fixed: Int!) on FIELD_DEFINITION
+
+          type Product {
+            upc: String!
+          }
+
+          type Query {
+            product: Product @complexity(fixed: 1)
+          }
+        GRAPHQL
+      )
+    end
+
     it 'returns valid SDL for type extensions' do
       product = Class.new(base_object) do
         graphql_name 'Product'
@@ -291,7 +383,7 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.0', default_link_namespace: 'fed2'
         end
 
         expect(execute_sdl(schema)).to match_sdl(
@@ -327,7 +419,7 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.0', default_link_namespace: 'fed2'
         end
 
         expect(execute_sdl(schema)).to match_sdl(
@@ -364,7 +456,7 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.0', default_link_namespace: 'fed2'
         end
 
         expect(execute_sdl(schema)).to match_sdl(
@@ -401,7 +493,7 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.0', default_link_namespace: 'fed2'
         end
 
         expect(execute_sdl(schema)).to match_sdl(
@@ -437,7 +529,7 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           query query_obj
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.0', default_link_namespace: 'fed2'
         end
 
         expect(execute_sdl(schema)).to match_sdl(
@@ -468,7 +560,7 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           orphan_types product
-          federation version: '2.0', link: { as: 'fed2' }
+          federation version: '2.0', default_link_namespace: 'fed2'
         end
 
         expect(execute_sdl(schema)).to match_sdl(
@@ -495,13 +587,13 @@ RSpec.describe ApolloFederation::ServiceField do
 
         schema = Class.new(base_schema) do
           orphan_types product
-          federation version: '2.3', link: { as: 'fed2' }
+          federation version: '2.3', default_link_namespace: 'fed2'
         end
 
         expect(execute_sdl(schema)).to match_sdl(
           <<~GRAPHQL,
             extend schema
-              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag"])
+              @link(url: "https://specs.apollo.dev/federation/v2.3", as: "fed2", import: ["@inaccessible", "@tag", "@composeDirective"])
 
             type Product @fed2__interfaceObject @fed2__key(fields: "id") {
               id: ID!
@@ -1421,7 +1513,7 @@ RSpec.describe ApolloFederation::ServiceField do
       expect(execute_sdl(schema)).to match_sdl(
         <<~GRAPHQL,
           extend schema
-            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag"])
+            @link(url: "https://specs.apollo.dev/federation/v2.3", import: ["@inaccessible", "@tag", "@composeDirective"])
 
           type Product @federation__interfaceObject @federation__key(fields: "id") {
             id: ID!
@@ -1973,7 +2065,7 @@ RSpec.describe ApolloFederation::ServiceField do
       end
 
       new_base_schema = Class.new(base_schema) do
-        federation version: '2.0', link: { as: 'fed2' }
+        federation version: '2.0', default_link_namespace: 'fed2'
       end
 
       schema = Class.new(new_base_schema) do
@@ -2011,7 +2103,7 @@ RSpec.describe ApolloFederation::ServiceField do
       end
 
       new_base_schema = Class.new(base_schema) do
-        federation version: '2.0', link: { as: 'fed2' }
+        federation version: '2.0', default_link_namespace: 'fed2'
         query query_obj
       end
 


### PR DESCRIPTION
Fixes https://github.com/Gusto/apollo-federation-ruby/issues/228

This PR adds support for `@composeDirective` as well as having multiple `@link` on the schema which is a prerequisite of the former. There's a breaking change `link`  -> `default_link_namespace` in the `federation` function because I felt like it makes more sense like this. Happy to hear your thoughts!