### PR TITLE
chore: update maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,5 +470,8 @@ See discussion at [#74](https://github.com/Gusto/apollo-federation-ruby/issues/7
 
 ## Maintainers
 
-- [Rylan Collins](https://github.com/rylanc)
-- [Noa Elad](https://github.com/noaelad)
+Gusto GraphQL Team:
+- [Sara Laupp](https://github.com/slauppy)
+- [Seth Copeland](https://github.com/sethc2)
+- [Simon Coffin](https://github.com/simoncoffin)
+- [Sofia Carrillo](https://github.com/sofie-c)


### PR DESCRIPTION
Hi folks! We now have a larger team primarily dedicated to working on our GraphQL related tooling and infrastructure. Thank you for your patience as we have been restructuring and organizing ourselves. We are still committed to maintaining this gem and look forward to collaborating on the existing open PRs.