### PR TITLE
fix: ensure query object is traversed

### DIFF
--- a/lib/apollo-federation/schema.rb
+++ b/lib/apollo-federation/schema.rb
@@ -42,18 +42,15 @@ module ApolloFederation
       end
 
       def query(new_query_object = nil)
-        if new_query_object
-          @orig_query_object = new_query_object
-        else
-          if !@federation_query_object
-            @federation_query_object = federation_query(original_query)
-            @federation_query_object.define_entities_field(schema_entities)
+        return super if new_query_object.nil? && @query_object
 
-            super(@federation_query_object)
-          end
+        @orig_query_object = new_query_object
+        federation_query_object = federation_query(original_query)
+        federation_query_object.define_entities_field(schema_entities)
 
-          super
-        end
+        super(federation_query_object)
+
+        federation_query_object
       end
 
       private

--- a/spec/apollo-federation/schema_spec.rb
+++ b/spec/apollo-federation/schema_spec.rb
@@ -3,6 +3,7 @@
 require 'spec_helper'
 require 'graphql'
 require 'apollo-federation/schema'
+require 'apollo-federation/object'
 
 RSpec.describe ApolloFederation::Schema do
   describe '.federation_version' do
@@ -95,6 +96,24 @@ RSpec.describe ApolloFederation::Schema do
       end
 
       expect(schema.federation_2?).to be(true)
+    end
+  end
+
+  describe '.query' do
+    it 'traverses the query type' do
+      cat_type = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'Cat'
+      end
+      query_type = Class.new(GraphQL::Schema::Object) do
+        graphql_name 'Query'
+        field :cat, cat_type, null: false
+      end
+      schema = Class.new(GraphQL::Schema) do
+        include ApolloFederation::Schema
+        query query_type
+      end
+
+      expect(schema.get_type('Cat')).to eq(cat_type)
     end
   end
 end


### PR DESCRIPTION
## Problem

The way we override the `Schema#query` method makes it so that we don't call `add_type_and_traverse` when setting the new query type like graphql-ruby does [here](https://github.com/rmosolgo/graphql-ruby/blob/5eac86139138332d17d4eb5ea3f59ae8e0aa8cfb/lib/graphql/schema.rb#L416). Currently we only add and traverse the query type when accessing the query.

The following script demonstrates this:

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'apollo-federation'
end

class CatType < GraphQL::Schema::Object
end

class QueryType < GraphQL::Schema::Object
  field :cat, CatType, null: false
end

class Schema < GraphQL::Schema
  include ApolloFederation::Schema

  query QueryType
end

p Schema.get_type('Cat')
#=> nil
```

## Solution

This PR makes it so that we call `super(federation_query_object)` when the new query object is being set.