### PR TITLE
fix: Warden no longer available in latest graphql gem versions

### DIFF
--- a/lib/apollo-federation/entities_field.rb
+++ b/lib/apollo-federation/entities_field.rb
@@ -38,7 +38,7 @@ module ApolloFederation
         references = references_with_indices.map(&:first)
         indices = references_with_indices.map(&:last)
 
-        type = context.types.type(typename)
+        type = context.schema.get_type(typename)
         if type.nil? || type.kind != GraphQL::TypeKinds::OBJECT
           # TODO: Raise a specific error class?
           raise "The _entities resolver tried to load an entity for type \"#{typename}\"," \

--- a/lib/apollo-federation/federated_document_from_schema_definition.rb
+++ b/lib/apollo-federation/federated_document_from_schema_definition.rb
@@ -69,7 +69,7 @@ module ApolloFederation
     def build_type_definition_nodes(types)
       non_federation_types = types.select do |type|
         if query_type?(type)
-          !@types.fields(type).all? { |field| FEDERATION_QUERY_FIELDS.include?(field.graphql_name) }
+          !warden.fields(type).all? { |field| FEDERATION_QUERY_FIELDS.include?(field.graphql_name) }
         else
           !FEDERATION_TYPES.include?(type.graphql_name)
         end
@@ -79,8 +79,12 @@ module ApolloFederation
 
     private
 
+    def warden
+      @warden ||= GraphQL::Schema::Warden.new(context: {}, schema: schema)
+    end
+
     def query_type?(type)
-      type == @types.query_root
+      type == warden.root_type_for_operation('query')
     end
 
     def merge_directives(node, type)


### PR DESCRIPTION
Fixes #276 

As explained in the issue, in the latest versions of `graphql`, the `warden` object is no longer available in most places.

It's mostly replaced by `@types` -- which I initially used in the first pass -- but since the warden object can still be constructed, doing so was the easiest route for backwards compatibility purposes.