### PR TITLE
Fix Apollo Federated Tracing (ftv1) with Apollo Router

### DIFF
--- a/lib/apollo-federation/tracing/tracer.rb
+++ b/lib/apollo-federation/tracing/tracer.rb
@@ -258,7 +258,7 @@ module ApolloFederation
 
         result[:extensions] ||= {}
         result[:extensions][ApolloFederation::Tracing::KEY] =
-          Base64.encode64(proto.class.encode(proto))
+          Base64.strict_encode64(proto.class.encode(proto))
 
         if result.context[:debug_tracing]
           result[:extensions][ApolloFederation::Tracing::DEBUG_KEY] = proto.to_h

--- a/spec/apollo-federation/entities_field_spec.rb
+++ b/spec/apollo-federation/entities_field_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe ApolloFederation::EntitiesField do
               let(:typename) { 'TypeNotInSchema' }
 
               it 'raises' do
-                expect(-> { execute_query }).to raise_error(
+                expect { execute_query }.to raise_error(
                   /The _entities resolver tried to load an entity for type "TypeNotInSchema"/,
                 )
               end

--- a/spec/apollo-federation/tracing_spec.rb
+++ b/spec/apollo-federation/tracing_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe ApolloFederation::Tracing do
     def trace(query)
       result = schema.execute(query, context: { tracing_enabled: true })
 
-      ApolloFederation::Tracing::Trace.decode(Base64.decode64(result[:extensions][:ftv1]))
+      ApolloFederation::Tracing::Trace.decode(Base64.strict_decode64(result[:extensions][:ftv1]))
     end
 
     describe 'building the trace tree' do


### PR DESCRIPTION
When using Apollo Federated tracing functionality with Apollo Router, Apollo Router did not report the subgraph tracing data to Apollo Studio. Based on https://github.com/Gusto/apollo-federation-ruby/issues/29 which claims the tracing should use `Base64.strict_encode64` so that in JS / Apollo Gateway the decoding is faster, I tried using it with Router and after Router would successfully report the trace data to Apollo Studio.