### PR TITLE
fix: tracer crash when no lazy query values

### DIFF
--- a/lib/apollo-federation/tracing/tracer.rb
+++ b/lib/apollo-federation/tracing/tracer.rb
@@ -24,12 +24,14 @@
 #
 #     <execute_field_lazy></execute_field_lazy>
 #
-#   </execute_query_lazy>
-#
-#   # `execute_query_lazy` *always* fires, so it's a
-#   # safe place to capture ending times of the full query.
-#
-# </execute_multiplex>
+  #   </execute_query_lazy>
+  #
+  #   # In graphql-ruby < 2.5.12, `execute_query_lazy` *always* fires.
+  #   # In graphql-ruby >= 2.5.12, `execute_query_lazy` only fires when there are lazy values.
+  #   # We record end times in both `execute_multiplex` (as a fallback) and `execute_query_lazy`
+  #   # (to capture the full execution time including lazy resolution when present).
+  #
+  # </execute_multiplex>
 
 module ApolloFederation
   module Tracing
@@ -95,6 +97,12 @@ module ApolloFederation
         data.fetch(:multiplex).queries.each { |query| start_trace(query) }
 
         results = block.call
+
+        # Step 4.5:
+        # Record end times for all queries.
+        # This acts as a fallback for queries without lazy values.
+        # execute_query_lazy will overwrite these times if lazy values are present.
+        data.fetch(:multiplex).queries.each { |query| record_trace_end_time(query) }
 
         # Step 5
         # Attach the trace to the 'extensions' key of each result


### PR DESCRIPTION
## Problem

The apollo-federation tracer crashes with "undefined method for nil" errors when using graphql-ruby 2.5.12 or later. This happens when accessing `end_time` because it's never being set for queries without lazy values.

## Root Cause

In graphql-ruby 2.5.12 ([commit 5ba154a561](https://github.com/rmosolgo/graphql-ruby/commit/5ba154a5613d4069c0b1d169c505caab96b0769d)), lazy execution handling was refactored and merged into the dataloader. As part of this change, the code that unconditionally called `execute_query_lazy` after every query was removed.

**Before 2.5.12:** `execute_query_lazy` was called for every query, regardless of whether lazy values were present.

**After 2.5.12:** `execute_query_lazy` only fires when there are actually lazy values to resolve.

The tracer relied on `execute_query_lazy` to set `end_time` for all queries (see line 29 comment: "execute_query_lazy *always* fires"). This assumption is no longer valid in graphql-ruby 2.5.12+.

## Solution

This PR adds a fallback in the `execute_multiplex` method to record end times for all queries after execution completes, before attaching traces to results.

**Behavior:**
- **Queries WITHOUT lazy values:** End times are recorded once in `execute_multiplex` (the fallback)
- **Queries WITH lazy values:** End times are recorded in `execute_multiplex`, then overwritten in `execute_query_lazy` to capture the full execution time including lazy resolution

This approach ensures:
1. ✅ End times are always set, preventing nil errors
2. ✅ Lazy execution times are still accurately captured when present
3. ✅ Backward compatibility with graphql-ruby < 2.5.12
4. ✅ Forward compatibility with graphql-ruby >= 2.5.12

## Changes

- Updated documentation comments to reflect the behavioral change in graphql-ruby 2.5.12+
- Added `record_trace_end_time` call in `execute_multiplex` as a fallback before attaching traces
- `execute_query_lazy` remains unchanged and continues to overwrite end times for lazy queries

## Testing

This fix can be verified by:
1. Running queries without lazy values on graphql-ruby 2.5.12+ (previously would crash, now works)
2. Running queries with lazy values on any version (should continue to work correctly)
3. Running the existing test suite to ensure no regressions